### PR TITLE
fix: logout

### DIFF
--- a/apps/web/src/lib/api/auth.ts
+++ b/apps/web/src/lib/api/auth.ts
@@ -2,7 +2,10 @@ import type { UpdateMeRequest, User } from '@garden/core/types'
 import { getApiTransport } from './state'
 
 export function logout(): Promise<void> {
-  return getApiTransport().request('/api/auth/sign-out', { method: 'POST' })
+  return getApiTransport().request('/api/auth/sign-out', {
+    method: 'POST',
+    body: '{}',
+  })
 }
 
 export function updateMe(data: UpdateMeRequest): Promise<User> {


### PR DESCRIPTION

**problem**

the logout button was broken. clicking it errored out and the session never got cleared, you'd think you logged out but you were still signed in.


the api transport always sends `content-type: application/json` on every request, even ones with no body. the logout call sent a bodyless post but with that json content-type header. better auth strictly parses the body when it sees json content-type, so an empty body = `400 invalid json in request body`. verified in the live nginx log and the better-call parser source.

**fix**

one line in `apps/web/src/lib/api/auth.ts`: give the sign-out request an explicit empty json body `{}` so better auth gets valid json it can parse.

**testing**

- live verified on the dev server: logout → 200, session cookie cleared, `get-session` → `null`
- manual ui test on the live site: logout works, redirects to login
- typecheck passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-out request handling to ensure logout works reliably across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->