### PR TITLE
fix(chat): add missing codemoderuntime dependency

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,6 +31,7 @@
     "@ai-sdk/react": "3.0.210",
     "@base-ui/react": "^1.3.0",
     "@cloudflare/ai-chat": "catalog:",
+    "@cloudflare/codemode": "catalog:",
     "@cloudflare/sandbox": "catalog:",
     "@cloudflare/think": "catalog:",
     "@cloudflare/vite-plugin": "catalog:",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -16,6 +16,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { cloudflare } from '@cloudflare/vite-plugin'
 import posthogRollupPlugin from '@posthog/rollup-plugin'
 import agents from 'agents/vite'
+import codemode from '@cloudflare/codemode/vite'
 
 const legacyEnvFiles = [
   fileURLToPath(new URL('./.env', import.meta.url)),
@@ -286,6 +287,7 @@ const config = defineConfig({
       },
     }),
     agents(),
+    codemode(),
     tailwindcss(),
     tanstackStart(),
     viteReact(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       '@cloudflare/ai-chat':
         specifier: 'catalog:'
         version: 0.8.6(@ai-sdk/react@3.0.210(react@19.2.3)(zod@4.4.3))(agents@0.17.3(patch_hash=f8a0c4465c3386d8ad820ec5087772e412388e5641ad97558ae79d3bc521e825)(@ai-sdk/react@3.0.210(react@19.2.3)(zod@4.4.3))(@babel/core@7.29.6)(@babel/runtime@7.29.2)(@cloudflare/workers-types@5.20260808.1)(ai@6.0.208(zod@4.4.3))(chat@4.30.0(ai@6.0.208(zod@4.4.3))(zod@4.4.3))(just-bash@3.0.1)(react@19.2.3)(rolldown@1.2.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.3))(ai@6.0.208(zod@4.4.3))(react@19.2.3)(zod@4.4.3)
+      '@cloudflare/codemode':
+        specifier: 'catalog:'
+        version: 0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.208(zod@4.4.3))(zod@4.4.3)
       '@cloudflare/sandbox':
         specifier: 'catalog:'
         version: 0.12.4


### PR DESCRIPTION
**problem**

someone in the wa gc pointed out agent chat crashes console throws: CodemodeRuntime is not exported from this Worker entry so the agent doesnt boot

**root cause**

the worker entry needs to export `CodemodeRuntime` for the chat agent runtime to spawn. the `@cloudflare/codemode/vite` plugin injects that export automatically at build time, but it was never added to `apps/web/vite.config.ts`. the app already depended on `@cloudflare/codemode` transitively through `@garden/agent-runtime`, but the plugin itself wasn't wired in and `apps/web` didn't declare the package directly.

**fix**

- add `@cloudflare/codemode` to `apps/web` dependencies (catalog)
- import and register the `codemode()` vite plugin in `apps/web/vite.config.ts`
- lockfile updated for the new direct dep

**testing**

- confirmed the vite plugin transform injects `export { CodemodeRuntime } from "@cloudflare/codemode"` into the worker entry
- typecheck passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cloudflare Codemode support to the web application.
  * Enabled Codemode integration during the application build and development process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->