### PR TITLE
test(deploy): enforce codemode Worker export

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,10 +9,11 @@
   "scripts": {
     "dev": "node ./scripts/dev.mjs --containers",
     "dev:local": "node ./scripts/dev.mjs",
-    "build": "pnpm run typecheck && vite build",
+    "build": "pnpm run typecheck && vite build && pnpm run verify:worker-entry",
     "preview": "vite preview",
     "worker:types": "wrangler types worker-configuration.d.ts --include-runtime false --env-file ../../.env.example",
     "worker:types:check": "wrangler types worker-configuration.d.ts --include-runtime false --env-file ../../.env.example --check",
+    "verify:worker-entry": "node ./scripts/verify-worker-entry.mjs",
     "skills:seed-builtin": "python3 ./scripts/seed_builtin_skills.py",
     "typecheck": "pnpm run worker:types && tsc -p tsconfig.executor.json --pretty false && tsc -b tsconfig.shared.json --pretty false && tsc -b tsconfig.server.json --pretty false && tsc -b tsconfig.entry.json --pretty false && tsc -p tsconfig.client.json --pretty false && tsc -p tsconfig.tooling.json --pretty false",
     "test": "vitest run",

--- a/apps/web/scripts/verify-worker-entry.mjs
+++ b/apps/web/scripts/verify-worker-entry.mjs
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+/**
+ * Codemode 0.4 moved execute-tool persistence into a Worker facet resolved from
+ * `ctx.exports`. TypeScript and Vite both succeed when that runtime export is
+ * absent, so inspect the final Worker artifact and fail the build before deploy.
+ * Reference: installed `@cloudflare/codemode/docs/vite-plugin.md`.
+ */
+const workerBundle = readFileSync(
+  new URL('../dist/server/index.js', import.meta.url),
+  'utf8',
+)
+
+assert.equal(
+  /export\s*\{[^}]*\bCodemodeRuntime\b[^}]*\}/s.test(workerBundle),
+  true,
+  'Worker bundle must export CodemodeRuntime for createExecuteTool()',
+)
+
+console.log('worker entry passed: CodemodeRuntime is exported')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: 0.8.6
       version: 0.8.6
     '@cloudflare/codemode':
-      specifier: 0.4.1
-      version: 0.4.1
+      specifier: 0.4.3
+      version: 0.4.3
     '@cloudflare/sandbox':
       specifier: 0.12.4
       version: 0.12.4
@@ -167,7 +167,7 @@ importers:
         version: 0.8.6(@ai-sdk/react@3.0.210(react@19.2.3)(zod@4.4.3))(agents@0.17.3(patch_hash=f8a0c4465c3386d8ad820ec5087772e412388e5641ad97558ae79d3bc521e825)(@ai-sdk/react@3.0.210(react@19.2.3)(zod@4.4.3))(@babel/core@7.29.6)(@babel/runtime@7.29.2)(@cloudflare/workers-types@5.20260808.1)(ai@6.0.208(zod@4.4.3))(chat@4.30.0(ai@6.0.208(zod@4.4.3))(zod@4.4.3))(just-bash@3.0.1)(react@19.2.3)(rolldown@1.2.3)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0))(zod@4.4.3))(ai@6.0.208(zod@4.4.3))(react@19.2.3)(zod@4.4.3)
       '@cloudflare/codemode':
         specifier: 'catalog:'
-        version: 0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.208(zod@4.4.3))(zod@4.4.3)
+        version: 0.4.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.208(zod@4.4.3))(zod@4.4.3)
       '@cloudflare/sandbox':
         specifier: 'catalog:'
         version: 0.12.4
@@ -597,7 +597,7 @@ importers:
         version: 2.0.47(zod@4.4.3)
       '@cloudflare/codemode':
         specifier: 'catalog:'
-        version: 0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.208(zod@4.4.3))(zod@4.4.3)
+        version: 0.4.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.208(zod@4.4.3))(zod@4.4.3)
       '@cloudflare/playwright':
         specifier: ^1.3.0
         version: 1.3.0
@@ -1590,23 +1590,6 @@ packages:
       ai: ^6.0.0
       react: ^19.0.0
       zod: ^4.0.0
-
-  '@cloudflare/codemode@0.4.1':
-    resolution: {integrity: sha512-i73cD7GeEzJVxcjqb4yPDCXXq7/h/Le/Vvz/Z3Xxf5qFiiw9G75fd1+KGWvZ/3/Gk6bgL7eUnnwMhByK3b5EUg==}
-    peerDependencies:
-      '@modelcontextprotocol/sdk': 1.30.0
-      '@tanstack/ai': '>=0.8.0 <1.0.0'
-      ai: ^6.0.0
-      zod: ^4.0.0
-    peerDependenciesMeta:
-      '@modelcontextprotocol/sdk':
-        optional: true
-      '@tanstack/ai':
-        optional: true
-      ai:
-        optional: true
-      zod:
-        optional: true
 
   '@cloudflare/codemode@0.4.3':
     resolution: {integrity: sha512-S6LIqj/NnmFRFxm3j0tPEGMF8HQF5DpV7sQg/W+U48YmnznTKOBcbS8eiV7SxBpIITLuMBcL4KpTDm1RDL20pA==}
@@ -10231,15 +10214,6 @@ snapshots:
       ai: 6.0.208(zod@4.4.3)
       nanoid: 5.1.16
       react: 19.2.3
-      zod: 4.4.3
-
-  '@cloudflare/codemode@0.4.1(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.208(zod@4.4.3))(zod@4.4.3)':
-    dependencies:
-      '@types/json-schema': 7.0.15
-      acorn: 8.17.0
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
-      ai: 6.0.208(zod@4.4.3)
       zod: 4.4.3
 
   '@cloudflare/codemode@0.4.3(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.208(zod@4.4.3))(zod@4.4.3)':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ catalog:
   "@cloudflare/ai-chat": "0.8.6"
   "@cloudflare/sandbox": "0.12.4"
   "@cloudflare/shell": "0.4.0"
-  "@cloudflare/codemode": "0.4.1"
+  "@cloudflare/codemode": "0.4.3"
   "@cloudflare/think": "0.10.0"
   "@cloudflare/vite-plugin": "1.37.3"
   "@cloudflare/workers-types": "5.20260808.1"

--- a/scripts/verify-deploy-config.mjs
+++ b/scripts/verify-deploy-config.mjs
@@ -171,6 +171,12 @@ assert.match(alchemySource, /empty:\s*deployTarget\.emptyBucketsOnDestroy/)
 assert.match(alchemySource, /deploymentTargetFromEnv\(\)/)
 assert.equal(webPackageJson.devDependencies['@posthog/cli'], '0.8.4')
 assert.equal(packageJson.pnpm.overrides['@posthog/cli'], '0.8.4')
+assert.equal(webPackageJson.dependencies['@cloudflare/codemode'], 'catalog:')
+assert.match(
+  viteSource,
+  /import codemode from ['"]@cloudflare\/codemode\/vite['"]/,
+)
+assert.match(viteSource, /\bcodemode\(\),/)
 assert.match(alchemySource, /POSTHOG_CLI_SOURCEMAP_UPLOAD_CONCURRENCY/)
 assert.match(alchemySource, /WORKERS_CI_COMMIT_SHA/)
 assert.match(viteSource, /WORKERS_CI_COMMIT_SHA/)


### PR DESCRIPTION
Adds a post-build assertion for the exact Worker export contract that caused the staging chat outage, verifies codemode plugin wiring in deploy config checks, and aligns the direct codemode version with Think/Shell to remove the duplicate runtime copy.\n\nVerified locally:\n- pnpm run verify:deploy-config\n- pnpm --filter @garden/web build\n- pnpm --filter @garden/web lint\n- targeted oxfmt check