### PR TITLE
fix(web): enable ctx exports for codemode runtime

### DIFF
--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -153,7 +153,11 @@ export const web = await TanStackStart(deployTarget.workerId, {
   cwd: './apps/web',
   adopt: true,
   compatibilityDate: '2026-04-18',
-  compatibilityFlags: ['nodejs_compat'],
+  // Codemode stores execution state in a Durable Object facet resolved through
+  // `this.ctx.exports.CodemodeRuntime`. Exporting the class is only half of the
+  // contract: Workers must also enable the ctx.exports runtime API. Reference:
+  // https://developers.cloudflare.com/workers/runtime-apis/context/#exports
+  compatibilityFlags: ['nodejs_compat', 'enable_ctx_exports'],
   observability: {
     enabled: true,
     headSamplingRate: 1,

--- a/apps/web/wrangler.containers.jsonc
+++ b/apps/web/wrangler.containers.jsonc
@@ -2,7 +2,9 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "garden-local",
   "compatibility_date": "2026-04-18",
-  "compatibility_flags": ["nodejs_compat"],
+  // @cloudflare/codemode resolves its exported runtime facet through
+  // DurableObjectState.exports; keep this aligned with alchemy.run.ts.
+  "compatibility_flags": ["nodejs_compat", "enable_ctx_exports"],
   "main": "src/server.ts",
   "observability": {
     "enabled": true,

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -2,7 +2,9 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "garden-staging",
   "compatibility_date": "2026-04-18",
-  "compatibility_flags": ["nodejs_compat"],
+  // @cloudflare/codemode resolves its exported runtime facet through
+  // DurableObjectState.exports; keep this aligned with alchemy.run.ts.
+  "compatibility_flags": ["nodejs_compat", "enable_ctx_exports"],
   "main": "src/server.ts",
   "observability": {
     "enabled": true,

--- a/scripts/verify-deploy-config.mjs
+++ b/scripts/verify-deploy-config.mjs
@@ -177,6 +177,18 @@ assert.match(
   /import codemode from ['"]@cloudflare\/codemode\/vite['"]/,
 )
 assert.match(viteSource, /\bcodemode\(\),/)
+assert.match(
+  alchemySource,
+  /compatibilityFlags:\s*\[[^\]]*['"]enable_ctx_exports['"]/,
+  'Alchemy deploy must enable ctx.exports for the CodemodeRuntime facet',
+)
+for (const source of publicWranglerSources) {
+  assert.match(
+    source,
+    /"compatibility_flags"\s*:\s*\[[^\]]*"enable_ctx_exports"/,
+    'Public Wrangler configs must enable ctx.exports for the CodemodeRuntime facet',
+  )
+}
 assert.match(alchemySource, /POSTHOG_CLI_SOURCEMAP_UPLOAD_CONCURRENCY/)
 assert.match(alchemySource, /WORKERS_CI_COMMIT_SHA/)
 assert.match(viteSource, /WORKERS_CI_COMMIT_SHA/)


### PR DESCRIPTION
## Root cause

`CodemodeRuntime` was present in Worker version 91, but Cloudflare reported only `nodejs_compat`. `@cloudflare/codemode` resolves the facet through `DurableObjectState.exports`, which requires the `enable_ctx_exports` compatibility flag. The SDK therefore still received `undefined` at runtime.

## Fix

- enable `enable_ctx_exports` in the authoritative Alchemy deployment
- keep both public Wrangler configs aligned
- fail deploy config verification if the flag disappears

## Verification

- `pnpm run verify:deploy-config`
- `pnpm --filter @garden/web worker:types:check`
- `pnpm typecheck`
- `git diff --check`

After merge, staging will be redeployed and an authenticated websocket chat turn verified against the new Worker version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cloudflare Worker deployment compatibility for Codemode’s Durable Object runtime.
  * Added deployment validation to ensure required runtime compatibility settings are enabled consistently.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->