### PR TITLE
fix(deploy): remove redundant ctx exports flag

### DIFF
--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -153,11 +153,7 @@ export const web = await TanStackStart(deployTarget.workerId, {
   cwd: './apps/web',
   adopt: true,
   compatibilityDate: '2026-04-18',
-  // Codemode stores execution state in a Durable Object facet resolved through
-  // `this.ctx.exports.CodemodeRuntime`. Exporting the class is only half of the
-  // contract: Workers must also enable the ctx.exports runtime API. Reference:
-  // https://developers.cloudflare.com/workers/runtime-apis/context/#exports
-  compatibilityFlags: ['nodejs_compat', 'enable_ctx_exports'],
+  compatibilityFlags: ['nodejs_compat'],
   observability: {
     enabled: true,
     headSamplingRate: 1,

--- a/apps/web/wrangler.containers.jsonc
+++ b/apps/web/wrangler.containers.jsonc
@@ -2,9 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "garden-local",
   "compatibility_date": "2026-04-18",
-  // @cloudflare/codemode resolves its exported runtime facet through
-  // DurableObjectState.exports; keep this aligned with alchemy.run.ts.
-  "compatibility_flags": ["nodejs_compat", "enable_ctx_exports"],
+  "compatibility_flags": ["nodejs_compat"],
   "main": "src/server.ts",
   "observability": {
     "enabled": true,

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -2,9 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "garden-staging",
   "compatibility_date": "2026-04-18",
-  // @cloudflare/codemode resolves its exported runtime facet through
-  // DurableObjectState.exports; keep this aligned with alchemy.run.ts.
-  "compatibility_flags": ["nodejs_compat", "enable_ctx_exports"],
+  "compatibility_flags": ["nodejs_compat"],
   "main": "src/server.ts",
   "observability": {
     "enabled": true,

--- a/scripts/verify-deploy-config.mjs
+++ b/scripts/verify-deploy-config.mjs
@@ -177,18 +177,6 @@ assert.match(
   /import codemode from ['"]@cloudflare\/codemode\/vite['"]/,
 )
 assert.match(viteSource, /\bcodemode\(\),/)
-assert.match(
-  alchemySource,
-  /compatibilityFlags:\s*\[[^\]]*['"]enable_ctx_exports['"]/,
-  'Alchemy deploy must enable ctx.exports for the CodemodeRuntime facet',
-)
-for (const source of publicWranglerSources) {
-  assert.match(
-    source,
-    /"compatibility_flags"\s*:\s*\[[^\]]*"enable_ctx_exports"/,
-    'Public Wrangler configs must enable ctx.exports for the CodemodeRuntime facet',
-  )
-}
 assert.match(alchemySource, /POSTHOG_CLI_SOURCEMAP_UPLOAD_CONCURRENCY/)
 assert.match(alchemySource, /WORKERS_CI_COMMIT_SHA/)
 assert.match(viteSource, /WORKERS_CI_COMMIT_SHA/)


### PR DESCRIPTION
## What changed\n- remove explicit `enable_ctx_exports` from Alchemy and Wrangler configs\n- remove invalid deploy guard\n- retain CodemodeRuntime final-bundle export verification from #74\n\n## Why\nCloudflare enables `ctx.exports` by default for our 2026-04-18 compatibility date and rejects the explicit flag with validation error 10021. Live v91 export-only build completed a fresh authenticated chat turn successfully; earlier post-deploy browser error was replayed from a failed pre-fix session.\n\n## Verification\n- `pnpm run verify:deploy-config`\n- `pnpm --filter @garden/web worker:types:check`\n- authenticated staging chat returned exact requested response on v91\n