### PR TITLE
feat(web): prompt stale tabs to refresh

### DIFF
--- a/apps/web/src/components/app-update-notice.test.tsx
+++ b/apps/web/src/components/app-update-notice.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+const forceRefresh = vi.hoisted(() => vi.fn())
+const updateSnapshot = vi.hoisted(
+  () => ({ kind: 'update-available', version: 'release-b' }) as const,
+)
+
+vi.mock('@/lib/app-version', () => ({
+  appVersionStore: {
+    subscribe: () => () => undefined,
+    getSnapshot: () => updateSnapshot,
+    getServerSnapshot: () => updateSnapshot,
+  },
+  forceRefresh,
+  removeRefreshMarker: vi.fn(),
+}))
+
+import { AppUpdateNotice } from './app-update-notice'
+
+describe('AppUpdateNotice', () => {
+  it('keeps the update action visible and refreshes to the discovered release', () => {
+    render(<AppUpdateNotice />)
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Update available. Refresh Garden',
+      }),
+    )
+
+    expect(screen.getByText('Update available')).toBeVisible()
+    expect(forceRefresh).toHaveBeenCalledWith('release-b')
+  })
+})

--- a/apps/web/src/components/app-update-notice.tsx
+++ b/apps/web/src/components/app-update-notice.tsx
@@ -1,0 +1,41 @@
+import { useSyncExternalStore } from 'react'
+import { RefreshCw } from 'lucide-react'
+import {
+  appVersionStore,
+  forceRefresh,
+  removeRefreshMarker,
+} from '@/lib/app-version'
+
+removeRefreshMarker()
+
+/**
+ * Shows a persistent bottom-left deploy notice modeled after T3 Code's update
+ * pill. It is deliberately separate from transient Sonner toasts: stale tabs
+ * need a durable action until the new browser bundle has loaded.
+ */
+export function AppUpdateNotice() {
+  const snapshot = useSyncExternalStore(
+    appVersionStore.subscribe,
+    appVersionStore.getSnapshot,
+    appVersionStore.getServerSnapshot,
+  )
+
+  if (snapshot.kind !== 'update-available') return null
+
+  return (
+    <div className="fixed bottom-[max(0.75rem,env(safe-area-inset-bottom))] left-[max(0.75rem,env(safe-area-inset-left))] z-50">
+      <button
+        type="button"
+        aria-label="Update available. Refresh Garden"
+        className="group flex h-9 items-center gap-2 rounded-lg border border-primary/20 bg-primary/15 px-3 text-xs font-medium text-primary shadow-lg shadow-black/10 backdrop-blur-xl transition-colors hover:bg-primary/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        onClick={() => forceRefresh(snapshot.version)}
+      >
+        <RefreshCw className="size-3.5 transition-transform duration-300 group-hover:rotate-45" />
+        <span>Update available</span>
+        <span className="border-l border-primary/20 pl-2 font-semibold">
+          Refresh
+        </span>
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/components/web-providers.tsx
+++ b/apps/web/src/components/web-providers.tsx
@@ -4,6 +4,7 @@ import { Toaster } from '@garden/ui/components/ui/sonner'
 import { WebNavigationProvider } from '@/platform/navigation'
 import { api, configureApi } from '@/lib/api'
 import { resetPostHogIdentity } from '@/lib/posthog-browser'
+import { AppUpdateNotice } from '@/components/app-update-notice'
 
 function redirectToLogin() {
   if (typeof window !== 'undefined') {
@@ -23,6 +24,7 @@ export function WebProviders({ children }: { children: React.ReactNode }) {
       >
         <WebNavigationProvider>{children}</WebNavigationProvider>
       </CoreProvider>
+      <AppUpdateNotice />
       <Toaster />
     </ThemeProvider>
   )

--- a/apps/web/src/garden-release.d.ts
+++ b/apps/web/src/garden-release.d.ts
@@ -1,0 +1,1 @@
+declare const __GARDEN_RELEASE_VERSION__: string

--- a/apps/web/src/lib/app-version.test.ts
+++ b/apps/web/src/lib/app-version.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest'
+import { Result } from 'better-result'
+import { createAppVersionStore, resolveVersionCheck } from './app-version'
+
+describe('app version checks', () => {
+  it('only advertises a different valid deployment', () => {
+    expect(resolveVersionCheck('release-a', null)).toEqual({
+      kind: 'unavailable',
+    })
+    expect(resolveVersionCheck('release-a', { version: 'release-a' })).toEqual({
+      kind: 'current',
+    })
+    expect(resolveVersionCheck('release-a', { version: 'release-b' })).toEqual({
+      kind: 'update-available',
+      version: 'release-b',
+    })
+  })
+
+  it('notifies subscribers when a new deployment appears', async () => {
+    const listener = vi.fn()
+    const store = createAppVersionStore('release-a', () =>
+      Promise.resolve(
+        Result.ok({
+          kind: 'update-available' as const,
+          version: 'release-b',
+        }),
+      ),
+    )
+
+    const unsubscribe = store.subscribe(listener)
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledOnce())
+
+    expect(store.getSnapshot()).toEqual({
+      kind: 'update-available',
+      version: 'release-b',
+    })
+    unsubscribe()
+  })
+})

--- a/apps/web/src/lib/app-version.ts
+++ b/apps/web/src/lib/app-version.ts
@@ -1,0 +1,157 @@
+import { Result, type UnhandledException } from 'better-result'
+
+const VERSION_MANIFEST_PATH = '/garden-version.json'
+const VERSION_CHECK_INTERVAL_MS = 60_000
+const CURRENT_VERSION_SNAPSHOT: AppVersionSnapshot = { kind: 'current' }
+
+export type AppVersionSnapshot =
+  | { kind: 'current' }
+  | { kind: 'update-available'; version: string }
+
+type VersionCheckOutcome =
+  | { kind: 'current' }
+  | { kind: 'unavailable' }
+  | { kind: 'update-available'; version: string }
+
+type VersionReader = () => Promise<
+  Result<VersionCheckOutcome, UnhandledException>
+>
+
+export const gardenReleaseVersion =
+  typeof __GARDEN_RELEASE_VERSION__ === 'string'
+    ? __GARDEN_RELEASE_VERSION__
+    : 'development'
+
+/**
+ * Validates the tiny static manifest before treating it as a deploy signal.
+ * Missing, malformed, and same-version responses are normal background
+ * outcomes; only a different non-empty version should interrupt the user.
+ */
+export function resolveVersionCheck(
+  currentVersion: string,
+  payload: unknown,
+): VersionCheckOutcome {
+  if (
+    !payload ||
+    typeof payload !== 'object' ||
+    !('version' in payload) ||
+    typeof payload.version !== 'string' ||
+    payload.version.length === 0
+  ) {
+    return { kind: 'unavailable' }
+  }
+
+  return payload.version === currentVersion
+    ? { kind: 'current' }
+    : { kind: 'update-available', version: payload.version }
+}
+
+/**
+ * Reads the current deployment marker without accepting browser or edge cache.
+ * Network and JSON failures remain typed recoverable errors; the UI boundary
+ * deliberately ignores them and checks again on the next focus/poll.
+ */
+function readDeployedVersion(
+  currentVersion: string,
+): Promise<Result<VersionCheckOutcome, UnhandledException>> {
+  return Result.tryPromise(async () => {
+    const url = new URL(VERSION_MANIFEST_PATH, window.location.origin)
+    url.searchParams.set('current', currentVersion)
+    const response = await window.fetch(url, {
+      cache: 'no-store',
+      headers: { accept: 'application/json' },
+    })
+    if (!response.ok) return { kind: 'unavailable' as const }
+    return resolveVersionCheck(currentVersion, await response.json())
+  })
+}
+
+/**
+ * Owns one shared deploy-version subscription without React effects. The first
+ * subscriber starts an immediate check plus focus/visibility checks and a
+ * low-frequency poll; the last subscriber tears all of them down. Once a new
+ * deploy is found the snapshot stays available and background traffic stops.
+ */
+export function createAppVersionStore(
+  currentVersion: string,
+  readVersion: VersionReader = () => readDeployedVersion(currentVersion),
+) {
+  let snapshot: AppVersionSnapshot = CURRENT_VERSION_SNAPSHOT
+  let interval: number | null = null
+  let checkInFlight: Promise<void> | null = null
+  const listeners = new Set<() => void>()
+
+  const stopChecks = () => {
+    if (interval !== null) {
+      window.clearInterval(interval)
+      interval = null
+    }
+    window.removeEventListener('focus', checkWhenActive)
+    document.removeEventListener('visibilitychange', checkWhenActive)
+  }
+
+  const applyOutcome = (outcome: VersionCheckOutcome) => {
+    if (outcome.kind !== 'update-available') return
+    snapshot = outcome
+    stopChecks()
+    for (const listener of listeners) listener()
+  }
+
+  const check = () => {
+    if (checkInFlight) return checkInFlight
+    checkInFlight = readVersion().then((result) => {
+      result.match({
+        ok: applyOutcome,
+        err: () => undefined,
+      })
+      checkInFlight = null
+    })
+    return checkInFlight
+  }
+
+  function checkWhenActive() {
+    if (document.visibilityState === 'visible') void check()
+  }
+
+  const startChecks = () => {
+    if (currentVersion === 'development' || interval !== null) return
+    void check()
+    interval = window.setInterval(checkWhenActive, VERSION_CHECK_INTERVAL_MS)
+    window.addEventListener('focus', checkWhenActive)
+    document.addEventListener('visibilitychange', checkWhenActive)
+  }
+
+  return {
+    getSnapshot: () => snapshot,
+    getServerSnapshot: () => CURRENT_VERSION_SNAPSHOT,
+    subscribe(listener: () => void) {
+      listeners.add(listener)
+      if (listeners.size === 1) startChecks()
+      return () => {
+        listeners.delete(listener)
+        if (listeners.size === 0) stopChecks()
+      }
+    },
+  }
+}
+
+export const appVersionStore = createAppVersionStore(gardenReleaseVersion)
+
+/**
+ * Performs a cache-busting navigation to the same screen, then removes the
+ * temporary marker from browser history after the new document starts.
+ */
+export function forceRefresh(version: string) {
+  const url = new URL(window.location.href)
+  url.searchParams.set('__garden_refresh', version)
+  window.location.replace(url)
+}
+
+/** Removes the force-refresh cache marker without another navigation. */
+export function removeRefreshMarker() {
+  if (typeof window === 'undefined') return
+  const url = new URL(window.location.href)
+  if (!url.searchParams.has('__garden_refresh')) return
+  url.searchParams.delete('__garden_refresh')
+  window.history.replaceState(window.history.state, '', url)
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -132,6 +132,7 @@ const postHogReleaseVersion =
   process.env.WORKERS_CI_COMMIT_SHA ??
   process.env.CF_PAGES_COMMIT_SHA ??
   process.env.GITHUB_SHA
+const gardenReleaseVersion = postHogReleaseVersion ?? 'development'
 const requirePostHogSourcemaps = process.env.GARDEN_REQUIRE_POSTHOG === '1'
 const baseLogger = createLogger()
 
@@ -224,6 +225,32 @@ function postHogSourcemapPlugins() {
   ]
 }
 
+/**
+ * Publishes the same immutable deploy identifier into browser code and a
+ * cache-busted static manifest. An already-open tab can compare the two after
+ * a deploy and ask the user to refresh, matching T3 Code's persistent update
+ * control instead of failing later when old code meets a new Worker. The
+ * release identifier comes from Alchemy/CI; local builds stay on `development`
+ * and intentionally do not advertise updates.
+ */
+function gardenReleasePlugin(releaseVersion: string): Plugin {
+  return {
+    name: 'garden-release-version',
+    config: () => ({
+      define: {
+        __GARDEN_RELEASE_VERSION__: JSON.stringify(releaseVersion),
+      },
+    }),
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'garden-version.json',
+        source: JSON.stringify({ version: releaseVersion }),
+      })
+    },
+  }
+}
+
 const config = defineConfig({
   clearScreen: false,
   envDir: rootDir,
@@ -275,6 +302,7 @@ const config = defineConfig({
   },
   plugins: [
     ...(enableDevtools ? [devtools()] : []),
+    gardenReleasePlugin(gardenReleaseVersion),
     ssrDependencyStubsPlugin(),
     cloudflare({
       viteEnvironment: { name: 'ssr' },


### PR DESCRIPTION
## Summary
- emit one deploy version into browser bundle and static manifest
- detect newer deployments without React effects
- show persistent T3-style bottom-left refresh control with cache-busted reload
- cover manifest validation, subscription, and refresh action

## Verification
- `pnpm --filter @garden/web exec vitest run src/lib/app-version.test.ts src/components/app-update-notice.test.tsx`
- `pnpm --filter @garden/web typecheck`
- `pnpm --filter @garden/web lint`
- `pnpm --filter @garden/web format`
- `POSTHOG_RELEASE_VERSION=refresh-notice-test pnpm --filter @garden/web build`
- final Worker artifact still exports `CodemodeRuntime`

Full web suite: 183 passed; unrelated container-backed integration suite cannot start because this host has no container runtime.