### PR TITLE
fix(web): require permissionManage for connector grants

### DIFF
--- a/apps/web/src/routes/api/connections/$connectorId/tools/$name/-grant.integration.test.ts
+++ b/apps/web/src/routes/api/connections/$connectorId/tools/$name/-grant.integration.test.ts
@@ -1,0 +1,157 @@
+import type { AppRequestContext } from '@/lib/server/context'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Route } from './grant'
+
+const mocks = vi.hoisted(() => ({
+  requireSession: vi.fn(),
+  resolveWorkspaceId: vi.fn(),
+  requireWorkspacePermission: vi.fn(),
+  capturePostHogEvent: vi.fn(),
+}))
+
+vi.mock('@/lib/server/control-plane', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/server/control-plane')>()
+  return {
+    ...actual,
+    requireSession: mocks.requireSession,
+    resolveWorkspaceId: mocks.resolveWorkspaceId,
+  }
+})
+
+vi.mock('@/lib/server/workspace-permissions', () => ({
+  requireWorkspacePermission: mocks.requireWorkspacePermission,
+  workspacePermissions: {
+    permissionManage: { permission: ['approve', 'grant'] },
+  },
+}))
+
+vi.mock('@/lib/posthog-server', () => ({
+  capturePostHogEvent: mocks.capturePostHogEvent,
+}))
+
+function getPatchHandler() {
+  const handlers = Route.options.server?.handlers
+
+  if (!handlers || typeof handlers === 'function') {
+    throw new Error('Expected connection grant route handlers')
+  }
+
+  const patchHandler = handlers.PATCH
+
+  if (typeof patchHandler !== 'function') {
+    throw new Error('Expected connection grant PATCH handler')
+  }
+
+  return patchHandler
+}
+
+describe('connection grant route authorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mocks.requireSession.mockResolvedValue({
+      user: { id: 'member-id' },
+    })
+    mocks.resolveWorkspaceId.mockResolvedValue('workspace-id')
+    mocks.requireWorkspacePermission.mockResolvedValue(
+      Response.json({ error: 'Forbidden' }, { status: 403 }),
+    )
+  })
+
+  it('rejects members without permissionManage before parsing the grant', async () => {
+    const request = new Request(
+      'https://garden.test/api/connections/github/tools/create_issue/grant',
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: 'invalid-json',
+      },
+    )
+
+    const response = await getPatchHandler()({
+      context: {} as AppRequestContext,
+      request,
+      params: {
+        connectorId: 'github',
+        name: 'create_issue',
+      },
+      pathname: '/api/connections/$connectorId/tools/$name/grant',
+      next: () => ({ isNext: true, context: undefined }),
+    })
+
+    expect(response).toBeInstanceOf(Response)
+    expect(response?.status).toBe(403)
+    expect(mocks.requireWorkspacePermission).toHaveBeenCalledWith({
+      appContext: expect.anything(),
+      request,
+      workspaceId: 'workspace-id',
+      permissions: {
+        permission: ['approve', 'grant'],
+      },
+    })
+  })
+
+  it('allows members with permissionManage to update the grant', async () => {
+    const agentId = '00000000-0000-4000-8000-000000000001'
+
+    const limit = vi
+      .fn()
+      .mockResolvedValueOnce([{ id: agentId }])
+      .mockResolvedValueOnce([
+        {
+          id: 'capability-id',
+          riskClass: 'write',
+        },
+      ])
+
+    const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined)
+
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit,
+          })),
+        })),
+      })),
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          onConflictDoUpdate,
+        })),
+      })),
+    }
+
+    mocks.requireWorkspacePermission.mockResolvedValueOnce(null)
+
+    const request = new Request(
+      'https://garden.test/api/connections/github/tools/create_issue/grant',
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          agentId,
+          trustLevel: 'allow',
+        }),
+      },
+    )
+
+    const response = await getPatchHandler()({
+      context: {
+        db: async () => db,
+      } as unknown as AppRequestContext,
+      request,
+      params: {
+        connectorId: 'github',
+        name: 'create_issue',
+      },
+      pathname: '/api/connections/$connectorId/tools/$name/grant',
+      next: () => ({ isNext: true, context: undefined }),
+    })
+
+    expect(response).toBeInstanceOf(Response)
+    expect(response?.status).toBe(200)
+    await expect(response?.json()).resolves.toEqual({ ok: true })
+    expect(onConflictDoUpdate).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/web/src/routes/api/connections/$connectorId/tools/$name/grant.ts
+++ b/apps/web/src/routes/api/connections/$connectorId/tools/$name/grant.ts
@@ -17,6 +17,10 @@ import {
 import { schema } from '@/lib/server/db'
 import { GARDEN_ANALYTICS_EVENTS } from '@garden/observability/analytics/events'
 import { capturePostHogEvent } from '@/lib/posthog-server'
+import {
+  requireWorkspacePermission,
+  workspacePermissions,
+} from '@/lib/server/workspace-permissions'
 
 type PermissionTrustLevel = 'auto' | 'allow' | 'ask'
 
@@ -65,6 +69,15 @@ export const Route = createFileRoute(
         if (!workspaceId) {
           return notFound('Workspace not found')
         }
+
+        const permission = await requireWorkspacePermission({
+          appContext,
+          request,
+          workspaceId,
+          permissions: workspacePermissions.permissionManage,
+        })
+
+        if (permission) return permission
 
         const payloadResult = await parseGrantPayload(request)
         if (payloadResult.isErr()) {


### PR DESCRIPTION
# Summary

The connector grant route allowed any workspace member to change an agent's tool trust level.

This change requires `permissionManage` before the route parses or updates a grant. Members without this permission now receive `403 Forbidden`. Authorized updates continue to use the existing grant upsert.

Closes #53.

## Scope

- In scope:
  - Require `workspacePermissions.permissionManage` on connector grant updates.
  - Check permission after resolving the workspace and before parsing the payload.
  - Test denied and authorized requests.
- Out of scope:
  - Permission-grant backfills from #37.
  - Changes to trust-level rules.
  - Authorization audits for other routes.
  - Schema or UI changes.

## Invariants

- Only workspace members with `permissionManage` can change connector grants.
- Agents and grants remain scoped to the resolved workspace.
- `auto` remains limited to read-only tools.
- Authorized requests keep the existing update behavior.

- [x] Canonical identity is defined where records/events are involved.
- [x] Re-running the operation does not duplicate effects.
- [x] Partial failure cannot silently corrupt state.
- [x] Public outputs do not expose private or internal data.

## Design

Better Auth remains the source of truth for workspace permissions.

The route resolves `workspaceId`, then calls the existing `requireWorkspacePermission` helper with `workspacePermissions.permissionManage`. A denied request returns before payload parsing or database access.

Authorized requests continue through the existing validation and permission-grant upsert. This uses the same permission helper as Garden's permission-resolution routes.

## Duplicate and idempotency review

- Stable idempotency/dedupe key: Existing `(agent_id, capability_id)` grant key.
- Persisted-data duplicate check: Existing unique constraint and upsert.
- Same-batch duplicate check: Not applicable.
- Retry behavior: A retry updates the same grant row.
- Conflict behavior: Existing grant values are updated through `onConflictDoUpdate`.

## Privacy and security review

- Data classification: Internal workspace authorization and grant data.
- Public fields explicitly allowlisted: Response bodies are unchanged.
- Private links/identifiers suppressed: No new output fields.
- Secrets and permissions reviewed: Adds the missing `permissionManage` check. No secret handling changes.

## Data, migration, and rollback

- Schema/data changes: None.
- Backup completed or not applicable: Not applicable.
- Dry-run/preview result: Not applicable.
- Expected affected-record count: None during deployment.
- Rollback procedure: Revert the commit.

## Verification

- [ ] Syntax/build/compile
- [x] Formatting/lint
- [x] Type checks
- [ ] Unit tests
- [x] Integration tests
- [ ] Repeat-run/idempotency test
- [x] Malformed-input test
- [ ] Partial-failure test
- [ ] Privacy-output test
- [ ] Before/after reconciliation

Commands and actual results:

```text
pnpm exec oxfmt -c ./.oxfmtrc.json --write \
  'apps/web/src/routes/api/connections/$connectorId/tools/$name/grant.ts' \
  'apps/web/src/routes/api/connections/$connectorId/tools/$name/-grant.integration.test.ts'
Completed.

pnpm --filter @garden/web exec oxlint -c ../../.oxlintrc.json \
  'src/routes/api/connections/$connectorId/tools/$name/grant.ts' \
  'src/routes/api/connections/$connectorId/tools/$name/-grant.integration.test.ts'
Passed.

pnpm --filter @garden/web typecheck
Passed.

pnpm --filter @garden/web exec vitest run \
  'src/routes/api/connections/$connectorId/tools/$name/-grant.integration.test.ts'
2 tests passed.

pnpm --filter @garden/web exec vitest run --maxWorkers=2
43 test files passed and 5 failed.
178 tests passed and 11 tests failed in suites outside this PR's changed files.
The reported failures included Issues page UI tests that remained in their loading state.
The connector grant authorization tests passed.
```

## Operations

- Configuration changes: None.
- Deployment/restart steps: Normal web deployment.
- Health checks: Confirm unauthorized members receive `403` and authorized members can update grants.
- Monitoring/alerts: No changes.
- Post-deploy verification: Exercise both permission paths against the deployed route.

## Agent declaration

- [x] I read the applicable `AGENTS.md` instructions.
- [x] I did not perform unapproved destructive production actions.
- [x] I have clearly stated any checks I could not run.
- [x] The patch does not include unrelated refactoring.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted connection grant updates to users with the required workspace management permission.
  * Unauthorized requests now receive a clear access-denied response before request validation.
  * Authorized grant updates continue to complete successfully.

* **Tests**
  * Added coverage for authorized and unauthorized connection grant update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->