### PR TITLE
Add Garden privacy policy and terms of service

### DIFF
--- a/apps/web/src/components/login-form.tsx
+++ b/apps/web/src/components/login-form.tsx
@@ -18,9 +18,9 @@ import { EyeIcon, EyeOffIcon, Loader2Icon } from 'lucide-react'
  * Why this shape: redesigned Aug 2026 to land on Garden's locked visual
  * language (parchment + vellum + foliage — see packages/ui/styles/tokens.css)
  * instead of the old generic two-column card. The previous right-hand
- * marketing rail and footer disclaimer were filler text and are intentionally
- * gone; the greeting carries no subtitle unless an invitation flow needs its
- * functional line (login-page.test.tsx pins those exact strings).
+ * marketing rail was filler and is intentionally gone; the greeting carries no
+ * subtitle unless an invitation flow needs its functional line. Sign-up now
+ * includes the real legal acknowledgement required for account creation.
  *
  * The deep-arched top ("greenhouse window") frames the brand mark and
  * greeting; the form lives in the rectangular zone below. The greeting is set
@@ -181,12 +181,10 @@ export function LoginForm({
             <FieldError>{error}</FieldError>
 
             <Field>
-              <Button
-                type="submit"
-                className="h-10 w-full"
-                disabled={loading}
-              >
-                {loading ? <Loader2Icon className="size-4 animate-spin" /> : null}
+              <Button type="submit" className="h-10 w-full" disabled={loading}>
+                {loading ? (
+                  <Loader2Icon className="size-4 animate-spin" />
+                ) : null}
                 {loading
                   ? isSignup
                     ? 'Creating account...'
@@ -207,6 +205,25 @@ export function LoginForm({
                 {isSignup ? 'Sign in' : 'Create an account'}
               </button>
             </FieldDescription>
+            {isSignup ? (
+              <FieldDescription className="text-center text-[11px] leading-4">
+                By creating an account, you agree to our{' '}
+                <a
+                  href="/terms"
+                  className="font-medium text-foreground underline underline-offset-4"
+                >
+                  Terms
+                </a>{' '}
+                and acknowledge our{' '}
+                <a
+                  href="/privacy"
+                  className="font-medium text-foreground underline underline-offset-4"
+                >
+                  Privacy Policy
+                </a>
+                .
+              </FieldDescription>
+            ) : null}
           </FieldGroup>
         </form>
       </div>

--- a/apps/web/src/features/auth/login-page.test.tsx
+++ b/apps/web/src/features/auth/login-page.test.tsx
@@ -138,6 +138,19 @@ describe('LoginPage', () => {
     )
   })
 
+  it('keeps privacy and terms available from the public auth surface', () => {
+    renderLoginPage()
+
+    expect(screen.getByRole('link', { name: 'Privacy' })).toHaveAttribute(
+      'href',
+      '/privacy',
+    )
+    expect(screen.getByRole('link', { name: 'Terms' })).toHaveAttribute(
+      'href',
+      '/terms',
+    )
+  })
+
   it('shows the auth error when Better Auth rejects the request', async () => {
     const user = userEvent.setup()
     const { onSuccess } = renderLoginPage()

--- a/apps/web/src/features/auth/login-page.tsx
+++ b/apps/web/src/features/auth/login-page.tsx
@@ -9,6 +9,11 @@ import {
   postHogBrowserClient,
 } from '@/lib/posthog-browser'
 
+/**
+ * Owns Garden's public authentication surface and its account-mode state.
+ * Privacy and terms now remain visible below the panel because `/login` is the
+ * current landing page after `/` redirects unauthenticated visitors here.
+ */
 export function LoginPage({
   onSuccess,
   initialEmail,
@@ -80,27 +85,43 @@ export function LoginPage({
   }
 
   return (
-    <div className="relative flex min-h-screen items-center justify-center overflow-hidden px-6 py-10">
+    <div className="relative flex min-h-dvh flex-col overflow-y-auto px-6 py-6">
       <LoginFoliage className="pointer-events-none absolute inset-x-0 bottom-0 mx-auto h-[clamp(180px,34vh,330px)] w-full max-w-6xl text-brand" />
-      <LoginForm
-        className="relative z-10 w-full max-w-sm"
-        mode={mode}
-        name={name}
-        email={email}
-        password={password}
-        error={error}
-        loading={loading}
-        onSubmit={handleSubmit}
-        onNameChange={setName}
-        emailReadonly={lockedEmail}
-        invitationStatusMessage={invitationStatusMessage}
-        invitationWorkspaceName={invitationWorkspaceName}
-        onEmailChange={lockedEmail ? () => undefined : setEmail}
-        onPasswordChange={setPassword}
-        onToggleMode={() =>
-          setMode((current) => (current === 'signin' ? 'signup' : 'signin'))
-        }
-      />
+      <main className="flex flex-1 items-center justify-center py-4">
+        <LoginForm
+          className="relative z-10 w-full max-w-sm"
+          mode={mode}
+          name={name}
+          email={email}
+          password={password}
+          error={error}
+          loading={loading}
+          onSubmit={handleSubmit}
+          onNameChange={setName}
+          emailReadonly={lockedEmail}
+          invitationStatusMessage={invitationStatusMessage}
+          invitationWorkspaceName={invitationWorkspaceName}
+          onEmailChange={lockedEmail ? () => undefined : setEmail}
+          onPasswordChange={setPassword}
+          onToggleMode={() =>
+            setMode((current) => (current === 'signin' ? 'signup' : 'signin'))
+          }
+        />
+      </main>
+      <footer className="relative z-10 flex items-center justify-center gap-4 pt-3 text-xs text-muted-foreground">
+        <a
+          href="/privacy"
+          className="transition-colors hover:text-foreground hover:underline hover:underline-offset-4"
+        >
+          Privacy
+        </a>
+        <a
+          href="/terms"
+          className="transition-colors hover:text-foreground hover:underline hover:underline-offset-4"
+        >
+          Terms
+        </a>
+      </footer>
     </div>
   )
 }

--- a/apps/web/src/features/legal/index.ts
+++ b/apps/web/src/features/legal/index.ts
@@ -1,0 +1,3 @@
+export { LegalDocument } from './legal-document'
+export { PrivacyPage } from './privacy-page'
+export { TermsPage } from './terms-page'

--- a/apps/web/src/features/legal/legal-document.tsx
+++ b/apps/web/src/features/legal/legal-document.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from 'react'
+import { BrandIcon } from '@garden/ui/components/common/brand-icon'
+
+/**
+ * Gives public legal documents one calm, readable shell that still belongs to
+ * Garden. The app document locks body scrolling for the workspace, so this
+ * surface owns its own viewport scroll instead of inheriting workspace chrome.
+ * Internal links stay plain anchors so these pages remain useful even before
+ * the client router hydrates. Routing references: installed TanStack Router
+ * core and navigation guidance.
+ */
+export function LegalDocument({
+  title,
+  summary,
+  effectiveDate,
+  children,
+}: {
+  title: string
+  summary: string
+  effectiveDate: string
+  children: ReactNode
+}) {
+  return (
+    <div className="h-dvh overflow-y-auto overscroll-y-contain text-foreground">
+      <header className="sticky top-0 z-10 border-b border-[color:var(--hairline-soft)] bg-[color:var(--parchment)]/90 backdrop-blur-xl">
+        <div className="mx-auto flex max-w-3xl items-center justify-between px-6 py-4 lg:px-10">
+          <a
+            href="/login"
+            className="inline-flex items-center gap-2 text-sm font-semibold transition-colors hover:text-[color:var(--moss)]"
+          >
+            <BrandIcon className="size-4" bordered noSpin size="sm" />
+            Garden
+          </a>
+          <a
+            href="/login"
+            className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Back to sign in
+          </a>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-3xl px-6 py-12 lg:px-10 lg:py-16">
+        <header className="border-b border-[color:var(--hairline-soft)] pb-10">
+          <p className="text-xs font-medium uppercase tracking-[0.2em] text-[color:var(--moss)]">
+            Legal
+          </p>
+          <h1 className="font-prose mt-3 text-4xl font-semibold tracking-tight sm:text-5xl">
+            {title}
+          </h1>
+          <p className="font-prose mt-5 max-w-2xl text-base leading-7 text-muted-foreground">
+            {summary}
+          </p>
+          <p className="mt-5 text-xs text-muted-foreground">
+            Effective {effectiveDate}
+          </p>
+        </header>
+
+        <article className="font-prose pb-12 text-[15px] leading-7 text-foreground/90 [&_a]:font-medium [&_a]:text-[color:var(--moss)] [&_a]:underline [&_a]:underline-offset-4 [&_h2]:mt-12 [&_h2]:text-xl [&_h2]:font-semibold [&_h2]:tracking-tight [&_li]:mt-2 [&_ol]:mt-4 [&_ol]:list-decimal [&_ol]:space-y-2 [&_ol]:pl-6 [&_p]:mt-4 [&_strong]:font-semibold [&_ul]:mt-4 [&_ul]:list-disc [&_ul]:space-y-2 [&_ul]:pl-6">
+          {children}
+        </article>
+      </main>
+
+      <footer className="border-t border-[color:var(--hairline-soft)]">
+        <div className="mx-auto flex max-w-3xl flex-wrap items-center gap-x-5 gap-y-2 px-6 py-6 text-xs text-muted-foreground lg:px-10">
+          <span>© 2026 Flow Research</span>
+          <a className="hover:text-foreground" href="/privacy">
+            Privacy
+          </a>
+          <a className="hover:text-foreground" href="/terms">
+            Terms
+          </a>
+        </div>
+      </footer>
+    </div>
+  )
+}

--- a/apps/web/src/features/legal/legal-pages.test.tsx
+++ b/apps/web/src/features/legal/legal-pages.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { PrivacyPage } from './privacy-page'
+import { TermsPage } from './terms-page'
+
+describe('public legal pages', () => {
+  it('renders the privacy notice with data and rights disclosures', () => {
+    render(<PrivacyPage />)
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Privacy Policy' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: '2. Information we collect' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('heading', { name: '10. Your rights and choices' }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders the service terms and links back to privacy', () => {
+    render(<TermsPage />)
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: 'Terms of Service' }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getAllByRole('link', { name: 'Privacy Policy' })[0],
+    ).toHaveAttribute('href', '/privacy')
+  })
+})

--- a/apps/web/src/features/legal/privacy-page.tsx
+++ b/apps/web/src/features/legal/privacy-page.tsx
@@ -1,0 +1,281 @@
+import { LegalDocument } from './legal-document'
+
+const EFFECTIVE_DATE = 'August 21, 2026'
+
+/** Public explanation of how Flow Research handles data in Garden. */
+export function PrivacyPage() {
+  return (
+    <LegalDocument
+      title="Privacy Policy"
+      summary="This policy explains what information Garden handles, why we use it, when it leaves your workspace, and the choices available to you."
+      effectiveDate={EFFECTIVE_DATE}
+    >
+      <section>
+        <h2>1. Who this policy covers</h2>
+        <p>
+          Garden is a workspace for people and AI agents, developed and operated
+          by Flow Research (“Garden,” “we,” “us,” or “our”). This policy applies
+          to the hosted Garden service, its websites, and related support
+          interactions (together, the “Service”).
+        </p>
+        <p>
+          If you use Garden through an employer or another organization, that
+          organization controls its workspace and may decide what information is
+          added, who may access it, and how long it is kept. For workspace
+          content we process on its instructions, your organization is normally
+          the controller or business and Flow Research acts as its processor or
+          service provider. Contact your workspace administrator first for
+          requests about organization-controlled content.
+        </p>
+      </section>
+
+      <section>
+        <h2>2. Information we collect</h2>
+        <p>We collect the following categories of information:</p>
+        <ul>
+          <li>
+            <strong>Account and profile information.</strong> Name, email
+            address, profile image, authentication records, workspace
+            memberships, invitations, roles, and account preferences. Passwords
+            are stored as cryptographic hashes, not readable plain text.
+          </li>
+          <li>
+            <strong>Workspace content.</strong> Chats and prompts, agent
+            outputs, issues, comments, documents, attachments, skills,
+            automation settings, approval decisions, and other material you or
+            your teammates submit to the Service.
+          </li>
+          <li>
+            <strong>Agent and activity records.</strong> Instructions, tool
+            requests and outcomes, run state, token and latency measurements,
+            audit events, and error details needed to operate and review agent
+            work.
+          </li>
+          <li>
+            <strong>Connected-service information.</strong> When you connect a
+            third-party service, we receive account identifiers, granted scopes,
+            authorization tokens, connection status, and information returned by
+            that service when you or an agent uses it. We only request access
+            required for the features you enable.
+          </li>
+          <li>
+            <strong>Device and usage information.</strong> IP address, user
+            agent, session identifiers, pages and product features used,
+            approximate location inferred from IP, timestamps, performance data,
+            and diagnostic events. Garden disables analytics session recording.
+          </li>
+          <li>
+            <strong>Communications.</strong> Information you provide when you
+            ask for support, report a problem, join research, or otherwise
+            contact us.
+          </li>
+        </ul>
+        <p>
+          We receive information directly from you, from your workspace and its
+          members, automatically from your device, and from services you choose
+          to connect. Please avoid placing sensitive personal information in
+          prompts or workspace content unless it is necessary and authorized.
+        </p>
+      </section>
+
+      <section>
+        <h2>3. How and why we use information</h2>
+        <p>We use information to:</p>
+        <ul>
+          <li>create accounts, authenticate users, and manage workspaces;</li>
+          <li>
+            provide chat, agents, issues, documents, automations, integrations,
+            permissions, and other requested features;
+          </li>
+          <li>
+            send service messages such as invitations, password resets, security
+            notices, and material product updates;
+          </li>
+          <li>
+            maintain security, prevent abuse, enforce permissions, investigate
+            incidents, and preserve audit history;
+          </li>
+          <li>
+            understand product performance, diagnose failures, and improve the
+            reliability and usability of Garden; and
+          </li>
+          <li>
+            comply with law and establish, exercise, or defend legal claims.
+          </li>
+        </ul>
+        <p>
+          Where applicable law requires a legal basis, we rely on performance of
+          our contract with you or your organization, our legitimate interests
+          in operating and securing the Service, compliance with legal
+          obligations, and consent where we specifically ask for it. You may
+          withdraw consent at any time, without affecting earlier processing.
+        </p>
+      </section>
+
+      <section>
+        <h2>4. AI processing and connected services</h2>
+        <p>
+          Garden sends the context needed to complete your request—such as
+          prompts, selected workspace content, tool definitions, and relevant
+          conversation history—to the AI model provider configured for the
+          deployment. Agents may also send information to a connected service
+          when you request an action or when an authorized automation runs.
+        </p>
+        <p>
+          Flow Research does not use private workspace content to train its own
+          general-purpose AI models. Model and integration providers process
+          information under their agreements with Flow Research or, for services
+          you connect directly, under the settings and terms applicable to your
+          account. AI output can be inaccurate. Garden records activity and
+          approval decisions so workspace members can review consequential agent
+          actions; Garden does not use AI to make legal or similarly significant
+          decisions about individuals on Flow Research’s behalf.
+        </p>
+      </section>
+
+      <section>
+        <h2>5. When we disclose information</h2>
+        <p>We may disclose information to:</p>
+        <ul>
+          <li>
+            <strong>Your workspace.</strong> Administrators and other members
+            can access information according to workspace roles, sharing
+            settings, and product behavior.
+          </li>
+          <li>
+            <strong>Infrastructure and service providers.</strong> Vendors that
+            support hosting, databases, file storage, AI inference, analytics,
+            error monitoring, email delivery, security, and customer support.
+            They may process information only to provide contracted services to
+            us.
+          </li>
+          <li>
+            <strong>Services you enable.</strong> Providers such as GitHub,
+            Google, Discord, Slack, or other connector and MCP services, when
+            you authorize a connection or ask Garden to use it.
+          </li>
+          <li>
+            <strong>Legal and safety recipients.</strong> Authorities, advisers,
+            or other parties when reasonably necessary to comply with law,
+            protect people and the Service, or investigate fraud or abuse.
+          </li>
+          <li>
+            <strong>Business transaction participants.</strong> A buyer,
+            successor, investor, or adviser in connection with a financing,
+            reorganization, merger, or sale, subject to appropriate safeguards.
+          </li>
+        </ul>
+        <p>
+          We do not sell personal information for money. We do not share
+          personal information for cross-context behavioral advertising, and we
+          do not use workspace content to target advertisements.
+        </p>
+      </section>
+
+      <section>
+        <h2>6. Cookies and local storage</h2>
+        <p>
+          Garden uses session cookies and similar storage required to keep you
+          signed in, protect requests, remember interface preferences, and
+          operate the Service. When analytics is enabled, we use PostHog to
+          measure page views, feature use, performance, and errors. Session
+          replay is disabled. You can control cookies through your browser, but
+          blocking essential storage may prevent sign-in or other features from
+          working.
+        </p>
+      </section>
+
+      <section>
+        <h2>7. International data transfers</h2>
+        <p>
+          Garden and its providers may process information in countries other
+          than the one where you live. Where required, we use recognized
+          transfer mechanisms and contractual safeguards designed to protect
+          personal information. Your organization may choose additional
+          providers or self-host Garden, which can change where its workspace
+          data is processed.
+        </p>
+      </section>
+
+      <section>
+        <h2>8. Retention</h2>
+        <p>
+          We keep account and workspace information while the applicable account
+          or workspace remains active and as needed to provide the Service. We
+          retain security, audit, backup, transaction, and support records for
+          as long as reasonably necessary for their purpose, legal obligations,
+          or dispute resolution. Retention may depend on workspace settings,
+          contractual commitments, the nature of the information, and technical
+          backup cycles. When information is no longer required, we delete or
+          de-identify it. Connected providers retain information under their own
+          policies.
+        </p>
+      </section>
+
+      <section>
+        <h2>9. Security</h2>
+        <p>
+          We use technical and organizational safeguards intended to protect
+          information, including access controls, encryption in transit,
+          secret-redaction practices, workspace isolation, and activity logs. No
+          method of storage or transmission is completely secure. Keep your
+          credentials confidential, use only trusted integrations, review agent
+          permissions, and tell us promptly if you suspect unauthorized access.
+        </p>
+      </section>
+
+      <section>
+        <h2>10. Your rights and choices</h2>
+        <p>
+          Depending on where you live, you may have rights to access, correct,
+          delete, restrict, object to, or receive a portable copy of personal
+          information; withdraw consent; or appeal a decision about a request.
+          You may also have the right to complain to your local data-protection
+          authority. We will not discriminate against you for exercising a
+          privacy right.
+        </p>
+        <p>
+          You can update some profile information in Garden, disconnect
+          integrations from connection settings, and ask a workspace
+          administrator to manage organization-controlled content. For a request
+          to Flow Research, use the “Start a conversation” contact at{' '}
+          <a href="https://flowresearch.tech/">flowresearch.tech</a> and label
+          your message “Privacy request.” We may verify your identity and
+          authority before acting. Authorized agents may submit requests where
+          permitted by law.
+        </p>
+      </section>
+
+      <section>
+        <h2>11. Children</h2>
+        <p>
+          Garden is a work service and is not directed to children under 16. We
+          do not knowingly collect personal information from children under 16.
+          If you believe a child has provided information to Garden, contact us
+          so we can investigate and take appropriate action.
+        </p>
+      </section>
+
+      <section>
+        <h2>12. Changes to this policy</h2>
+        <p>
+          We may update this policy as Garden, our providers, or applicable law
+          changes. We will post the revised policy with a new effective date
+          and, when a change materially affects your rights, provide additional
+          notice through the Service or by email where appropriate.
+        </p>
+      </section>
+
+      <section>
+        <h2>13. Contact</h2>
+        <p>
+          Flow Research is responsible for this policy. For privacy questions or
+          requests, use the “Start a conversation” contact at{' '}
+          <a href="https://flowresearch.tech/">flowresearch.tech</a> and
+          identify the message as a privacy matter. Do not post private account
+          or workspace information in a public GitHub issue.
+        </p>
+      </section>
+    </LegalDocument>
+  )
+}

--- a/apps/web/src/features/legal/terms-page.tsx
+++ b/apps/web/src/features/legal/terms-page.tsx
@@ -1,0 +1,325 @@
+import { LegalDocument } from './legal-document'
+
+const EFFECTIVE_DATE = 'August 21, 2026'
+
+/** Public contract for use of Flow Research's hosted Garden service. */
+export function TermsPage() {
+  return (
+    <LegalDocument
+      title="Terms of Service"
+      summary="These terms set the rules for using Garden’s hosted workspace, AI agents, automations, and connected tools."
+      effectiveDate={EFFECTIVE_DATE}
+    >
+      <section>
+        <h2>1. Agreement</h2>
+        <p>
+          These Terms of Service (“Terms”) are an agreement between you and Flow
+          Research (“Garden,” “we,” “us,” or “our”) governing your access to the
+          hosted Garden service, websites, agents, automations, integrations,
+          and related features (together, the “Service”). By creating an
+          account, joining a workspace, or using the Service, you agree to these
+          Terms and our <a href="/privacy">Privacy Policy</a>.
+        </p>
+        <p>
+          If you use Garden for an organization, you represent that you are
+          authorized to accept these Terms for it. “You” then includes that
+          organization. If you do not agree, do not use the Service.
+        </p>
+      </section>
+
+      <section>
+        <h2>2. Eligibility and accounts</h2>
+        <p>
+          You must be at least 18 years old or the age of legal majority where
+          you live and able to enter a binding contract. You must provide
+          accurate account information, protect your credentials, and promptly
+          update information that changes. You are responsible for activity
+          under your account unless you promptly report unauthorized use.
+        </p>
+        <p>
+          Workspace owners and administrators control membership, roles,
+          permissions, integrations, and workspace content. If an organization
+          provides your account, it may manage or remove your access and may
+          access information associated with its workspace. Resolve internal
+          access and ownership questions with your workspace administrator.
+        </p>
+      </section>
+
+      <section>
+        <h2>3. The Service</h2>
+        <p>
+          Garden helps people and AI agents collaborate through chat, issues,
+          documents, automations, approvals, skills, and connected services. We
+          may add, change, or discontinue features as the Service develops. We
+          aim to give reasonable notice when a material change will
+          significantly reduce a core paid feature, but early or experimental
+          features may change without notice.
+        </p>
+        <p>
+          You are responsible for your internet access, devices, workspace
+          configuration, backups of information you cannot afford to lose, and
+          compliance with laws and policies that apply to your use.
+        </p>
+      </section>
+
+      <section>
+        <h2>4. AI agents and automations</h2>
+        <p>
+          AI output is probabilistic and can be incomplete, inaccurate, or
+          unsuitable. Agents can take actions through tools and connected
+          accounts when permissions allow. You are responsible for configuring
+          permissions, reviewing material output, and applying human judgment
+          before relying on or publishing results or allowing consequential
+          actions.
+        </p>
+        <p>
+          Do not treat Garden output as a substitute for professional legal,
+          financial, medical, employment, safety, or other regulated advice. You
+          must independently verify information and obtain qualified advice when
+          the stakes require it. You remain responsible for decisions and
+          actions taken through your account, including agent and automation
+          actions you authorize.
+        </p>
+      </section>
+
+      <section>
+        <h2>5. Connected services</h2>
+        <p>
+          Garden may let you connect third-party services such as GitHub,
+          Google, Discord, Slack, model providers, or MCP servers. Your use of
+          those services is governed by their terms and privacy policies. You
+          authorize Garden to exchange information with them as needed to
+          provide the features you enable.
+        </p>
+        <p>
+          You must have authority to connect an account and grant each requested
+          permission. We are not responsible for third-party services, their
+          availability, or changes they make. Disconnecting a service may not
+          delete information already sent to or received from it.
+        </p>
+      </section>
+
+      <section>
+        <h2>6. Your content</h2>
+        <p>
+          You retain ownership of content you submit to Garden and output you
+          may own under applicable law (“Your Content”). You grant us a
+          worldwide, non-exclusive, royalty-free license to host, copy, process,
+          transmit, display, and modify Your Content only as reasonably
+          necessary to operate, secure, support, and improve the Service and to
+          follow your instructions. This license lasts while the content is
+          stored by the Service and for limited backup, legal, and security
+          retention afterward.
+        </p>
+        <p>
+          You represent that you have the rights and permissions needed to
+          submit Your Content and permit its processing. You are responsible for
+          Your Content, including personal information, confidential material,
+          and instructions given to agents. AI output may not be unique, and
+          other users may receive similar output. We do not promise that output
+          is protectable by intellectual-property law or free of third-party
+          rights.
+        </p>
+      </section>
+
+      <section>
+        <h2>7. Acceptable use</h2>
+        <p>You may not use the Service to:</p>
+        <ul>
+          <li>break the law or violate another person’s rights;</li>
+          <li>
+            create, upload, or distribute malware or facilitate unauthorized
+            access, phishing, fraud, harassment, exploitation, or violence;
+          </li>
+          <li>
+            probe, scan, disrupt, overload, or bypass security, permissions,
+            rate limits, or access controls, except under a written authorized
+            security-testing program;
+          </li>
+          <li>
+            access another account, workspace, system, or data without
+            authorization;
+          </li>
+          <li>
+            use Garden to make solely automated high-impact decisions about a
+            person in employment, housing, credit, insurance, education, health,
+            legal services, or similar contexts without lawful authority,
+            appropriate safeguards, and meaningful human review;
+          </li>
+          <li>
+            infringe intellectual-property, privacy, publicity, confidentiality,
+            or data-protection rights; or
+          </li>
+          <li>
+            resell or provide the Service to third parties unless we have agreed
+            in writing.
+          </li>
+        </ul>
+        <p>
+          You may conduct good-faith research on Garden’s open-source code under
+          its license. Testing the hosted Service still requires authorization
+          and must not risk other users or systems.
+        </p>
+      </section>
+
+      <section>
+        <h2>8. Our software and intellectual property</h2>
+        <p>
+          We and our licensors retain all rights in the Service, including its
+          branding, design, documentation, and software, except for Your Content
+          and rights expressly granted under an open-source license. Garden’s
+          source code is separately available under the license included with
+          that code. The open-source license governs your use of the source
+          code; these Terms govern your use of the hosted Service.
+        </p>
+        <p>
+          If you provide feedback, you grant us a perpetual, worldwide,
+          irrevocable, royalty-free right to use it without restriction or
+          compensation, provided we do not identify you publicly as its source
+          without permission.
+        </p>
+      </section>
+
+      <section>
+        <h2>9. Fees</h2>
+        <p>
+          Some features may be free, experimental, or offered under a separate
+          order or plan. If we introduce a charge, we will show the price and
+          applicable billing terms before you authorize payment. Taxes, provider
+          usage charges, and third-party fees may apply. Terms in an executed
+          order form control if they conflict with this section.
+        </p>
+      </section>
+
+      <section>
+        <h2>10. Privacy</h2>
+        <p>
+          Our <a href="/privacy">Privacy Policy</a> explains how we handle
+          personal information. You are responsible for providing any notices,
+          obtaining permissions, and establishing any processing terms required
+          for personal information you place in a workspace or send to connected
+          services.
+        </p>
+      </section>
+
+      <section>
+        <h2>11. Suspension and termination</h2>
+        <p>
+          You may stop using the Service at any time. Workspace administrators
+          may remove members or delete organization-controlled content. To
+          request closure of an account you cannot close in the product, contact
+          us.
+        </p>
+        <p>
+          We may limit, suspend, or terminate access if you materially breach
+          these Terms, create security or legal risk, fail to pay an authorized
+          charge, or use the Service in a way that could harm Garden, our
+          providers, or others. When practical, we will give notice and an
+          opportunity to fix the issue. We may act immediately for urgent risk
+          or legal requirements.
+        </p>
+        <p>
+          On termination, your right to use the Service ends. Provisions that by
+          their nature should survive—including ownership, disclaimers,
+          liability limits, indemnity, and dispute terms—will survive.
+        </p>
+      </section>
+
+      <section>
+        <h2>12. Disclaimers</h2>
+        <p>
+          To the maximum extent permitted by law, the Service is provided “as
+          is” and “as available.” Flow Research and its suppliers disclaim all
+          warranties, express, implied, or statutory, including merchantability,
+          fitness for a particular purpose, title, non-infringement, accuracy,
+          and uninterrupted or error-free operation. We do not warrant AI
+          output, connected services, or that the Service will meet every
+          requirement. Nothing in these Terms excludes a warranty that cannot
+          legally be excluded.
+        </p>
+      </section>
+
+      <section>
+        <h2>13. Limitation of liability</h2>
+        <p>
+          To the maximum extent permitted by law, Flow Research and its
+          suppliers will not be liable for indirect, incidental, special,
+          consequential, exemplary, or punitive damages, or for lost profits,
+          revenue, goodwill, data, or business interruption, arising from or
+          related to the Service, even if advised that such loss was possible.
+        </p>
+        <p>
+          Our total liability for all claims arising from or related to the
+          Service will not exceed the greater of (a) the amount you paid Flow
+          Research for the Service during the 12 months before the event giving
+          rise to the claim or (b) US$100. These limits do not apply where
+          prohibited by law or to liability that cannot legally be limited.
+        </p>
+      </section>
+
+      <section>
+        <h2>14. Indemnity</h2>
+        <p>
+          To the extent permitted by law, if you use the Service for an
+          organization, that organization will defend and indemnify Flow
+          Research and its personnel against third-party claims, damages, and
+          reasonable costs arising from Your Content, its use of the Service, or
+          its violation of these Terms or another person’s rights. This section
+          does not require an individual consumer to indemnify us where the law
+          prohibits it.
+        </p>
+      </section>
+
+      <section>
+        <h2>15. Governing law and disputes</h2>
+        <p>
+          These Terms are governed by the laws applicable to Flow Research as
+          operator of the Service, without regard to conflict-of-law rules.
+          Courts with jurisdiction over Flow Research will have exclusive
+          jurisdiction, except where mandatory consumer law gives you the right
+          to bring a claim elsewhere. Before filing a formal claim, each party
+          agrees to make a reasonable good-faith effort to resolve the dispute
+          informally. Nothing here prevents either party from seeking urgent
+          injunctive relief.
+        </p>
+      </section>
+
+      <section>
+        <h2>16. Changes to these Terms</h2>
+        <p>
+          We may update these Terms as the Service or law changes. We will post
+          the revised Terms with a new effective date. For material changes, we
+          will provide reasonable additional notice through the Service or by
+          email. Unless a different date is stated, changes take effect when
+          posted. Continued use after the effective date means you accept the
+          revised Terms; if you do not agree, stop using the Service.
+        </p>
+      </section>
+
+      <section>
+        <h2>17. General</h2>
+        <p>
+          These Terms, the Privacy Policy, and any applicable order form are the
+          entire agreement about the hosted Service. If a provision is
+          unenforceable, it will be narrowed to the minimum extent necessary and
+          the rest will remain effective. A failure to enforce a provision is
+          not a waiver. You may not assign these Terms without our consent; we
+          may assign them as part of a reorganization, financing, merger, sale,
+          or transfer of the Service. We are not liable for delay caused by
+          events beyond our reasonable control.
+        </p>
+      </section>
+
+      <section>
+        <h2>18. Contact</h2>
+        <p>
+          Questions about these Terms can be sent through the “Start a
+          conversation” contact at{' '}
+          <a href="https://flowresearch.tech/">flowresearch.tech</a>. Do not
+          post confidential account or workspace information in a public GitHub
+          issue.
+        </p>
+      </section>
+    </LegalDocument>
+  )
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -9,9 +9,11 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as TermsRouteImport } from './routes/terms'
 import { Route as SignupRouteImport } from './routes/signup'
 import { Route as RoadmapRouteImport } from './routes/roadmap'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
+import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as HarnessyRouteImport } from './routes/harnessy'
 import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
@@ -105,6 +107,11 @@ import { Route as ApiChatThreadsIdDocumentsRouteImport } from './routes/api/chat
 import { Route as ApiAutomationsIdTriggersTriggerIdRouteImport } from './routes/api/automations/$id/triggers/$triggerId'
 import { Route as ApiConnectionsConnectorIdToolsNameGrantRouteImport } from './routes/api/connections/$connectorId/tools/$name/grant'
 
+const TermsRoute = TermsRouteImport.update({
+  id: '/terms',
+  path: '/terms',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SignupRoute = SignupRouteImport.update({
   id: '/signup',
   path: '/signup',
@@ -118,6 +125,11 @@ const RoadmapRoute = RoadmapRouteImport.update({
 const ResetPasswordRoute = ResetPasswordRouteImport.update({
   id: '/reset-password',
   path: '/reset-password',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
   getParentRoute: () => rootRouteImport,
 } as any)
 const LoginRoute = LoginRouteImport.update({
@@ -608,9 +620,11 @@ export interface FileRoutesByFullPath {
   '/forgot-password': typeof ForgotPasswordRoute
   '/harnessy': typeof HarnessyRoute
   '/login': typeof LoginRoute
+  '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
   '/roadmap': typeof RoadmapRoute
   '/signup': typeof SignupRoute
+  '/terms': typeof TermsRoute
   '/workspace': typeof AuthenticatedWorkspaceRoute
   '/api/$': typeof ApiSplatRoute
   '/api/agents': typeof ApiAgentsRouteWithChildren
@@ -704,9 +718,11 @@ export interface FileRoutesByTo {
   '/forgot-password': typeof ForgotPasswordRoute
   '/harnessy': typeof HarnessyRoute
   '/login': typeof LoginRoute
+  '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
   '/roadmap': typeof RoadmapRoute
   '/signup': typeof SignupRoute
+  '/terms': typeof TermsRoute
   '/workspace': typeof AuthenticatedWorkspaceRoute
   '/api/$': typeof ApiSplatRoute
   '/api/agents': typeof ApiAgentsRouteWithChildren
@@ -802,9 +818,11 @@ export interface FileRoutesById {
   '/forgot-password': typeof ForgotPasswordRoute
   '/harnessy': typeof HarnessyRoute
   '/login': typeof LoginRoute
+  '/privacy': typeof PrivacyRoute
   '/reset-password': typeof ResetPasswordRoute
   '/roadmap': typeof RoadmapRoute
   '/signup': typeof SignupRoute
+  '/terms': typeof TermsRoute
   '/_authenticated/workspace': typeof AuthenticatedWorkspaceRoute
   '/api/$': typeof ApiSplatRoute
   '/api/agents': typeof ApiAgentsRouteWithChildren
@@ -900,9 +918,11 @@ export interface FileRouteTypes {
     | '/forgot-password'
     | '/harnessy'
     | '/login'
+    | '/privacy'
     | '/reset-password'
     | '/roadmap'
     | '/signup'
+    | '/terms'
     | '/workspace'
     | '/api/$'
     | '/api/agents'
@@ -996,9 +1016,11 @@ export interface FileRouteTypes {
     | '/forgot-password'
     | '/harnessy'
     | '/login'
+    | '/privacy'
     | '/reset-password'
     | '/roadmap'
     | '/signup'
+    | '/terms'
     | '/workspace'
     | '/api/$'
     | '/api/agents'
@@ -1093,9 +1115,11 @@ export interface FileRouteTypes {
     | '/forgot-password'
     | '/harnessy'
     | '/login'
+    | '/privacy'
     | '/reset-password'
     | '/roadmap'
     | '/signup'
+    | '/terms'
     | '/_authenticated/workspace'
     | '/api/$'
     | '/api/agents'
@@ -1191,9 +1215,11 @@ export interface RootRouteChildren {
   ForgotPasswordRoute: typeof ForgotPasswordRoute
   HarnessyRoute: typeof HarnessyRoute
   LoginRoute: typeof LoginRoute
+  PrivacyRoute: typeof PrivacyRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
   RoadmapRoute: typeof RoadmapRoute
   SignupRoute: typeof SignupRoute
+  TermsRoute: typeof TermsRoute
   ApiSplatRoute: typeof ApiSplatRoute
   ApiAgentsRoute: typeof ApiAgentsRouteWithChildren
   ApiAutomationsRoute: typeof ApiAutomationsRouteWithChildren
@@ -1232,6 +1258,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/terms': {
+      id: '/terms'
+      path: '/terms'
+      fullPath: '/terms'
+      preLoaderRoute: typeof TermsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/signup': {
       id: '/signup'
       path: '/signup'
@@ -1251,6 +1284,13 @@ declare module '@tanstack/react-router' {
       path: '/reset-password'
       fullPath: '/reset-password'
       preLoaderRoute: typeof ResetPasswordRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/login': {
@@ -2214,9 +2254,11 @@ const rootRouteChildren: RootRouteChildren = {
   ForgotPasswordRoute: ForgotPasswordRoute,
   HarnessyRoute: HarnessyRoute,
   LoginRoute: LoginRoute,
+  PrivacyRoute: PrivacyRoute,
   ResetPasswordRoute: ResetPasswordRoute,
   RoadmapRoute: RoadmapRoute,
   SignupRoute: SignupRoute,
+  TermsRoute: TermsRoute,
   ApiSplatRoute: ApiSplatRoute,
   ApiAgentsRoute: ApiAgentsRouteWithChildren,
   ApiAutomationsRoute: ApiAutomationsRouteWithChildren,

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { PrivacyPage } from '@/features/legal'
+
+const PRIVACY_TITLE = 'Privacy Policy — Garden'
+const PRIVACY_DESCRIPTION =
+  'How Flow Research collects, uses, shares, retains, and protects information when you use Garden.'
+
+export const Route = createFileRoute('/privacy')({
+  head: () => ({
+    meta: [
+      { title: PRIVACY_TITLE },
+      { name: 'description', content: PRIVACY_DESCRIPTION },
+      { property: 'og:title', content: PRIVACY_TITLE },
+      { property: 'og:description', content: PRIVACY_DESCRIPTION },
+      { name: 'twitter:title', content: PRIVACY_TITLE },
+      { name: 'twitter:description', content: PRIVACY_DESCRIPTION },
+    ],
+  }),
+  component: PrivacyPage,
+})

--- a/apps/web/src/routes/terms.tsx
+++ b/apps/web/src/routes/terms.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { TermsPage } from '@/features/legal'
+
+const TERMS_TITLE = 'Terms of Service — Garden'
+const TERMS_DESCRIPTION =
+  'Terms governing use of Garden’s hosted workspace, AI agents, automations, and connected tools.'
+
+export const Route = createFileRoute('/terms')({
+  head: () => ({
+    meta: [
+      { title: TERMS_TITLE },
+      { name: 'description', content: TERMS_DESCRIPTION },
+      { property: 'og:title', content: TERMS_TITLE },
+      { property: 'og:description', content: TERMS_DESCRIPTION },
+      { name: 'twitter:title', content: TERMS_TITLE },
+      { name: 'twitter:description', content: TERMS_DESCRIPTION },
+    ],
+  }),
+  component: TermsPage,
+})


### PR DESCRIPTION
## Summary
- add branded public Privacy Policy and Terms of Service routes
- expose legal links on the login/landing page and signup acknowledgement
- cover hosted AI processing, integrations, analytics, workspace controls, acceptable use, and liability terms

## Verification
- `pnpm --filter @garden/web typecheck`
- focused Oxlint: 0 errors, 0 warnings
- focused Vitest: 2 files, 9 tests passed

## Note
Policy identifies Flow Research as operator but intentionally does not invent a legal address or jurisdiction absent from project metadata. Counsel should confirm entity/contact details before a commercial launch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added publicly accessible Terms of Service and Privacy Policy pages.
  * Added `/terms` and `/privacy` routes with page metadata.
  * Added links to legal pages from the login and signup experience.
  * Added navigation between the Terms and Privacy pages.

* **Style**
  * Updated the authentication layout for improved scrolling and centered content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->