### PR TITLE
fix: comments idor on agent comments

### DIFF
--- a/apps/web/src/routes/api/comments/$id.ts
+++ b/apps/web/src/routes/api/comments/$id.ts
@@ -54,10 +54,7 @@ export const Route = createFileRoute('/api/comments/$id')({
           .where(eq(schema.issueComment.id, params.id))
         if (!existingComment) return notFound('Comment not found')
 
-        if (
-          existingComment.authorType === 'user' &&
-          existingComment.authorId !== session.user.id
-        ) {
+        if (existingComment.authorId !== session.user.id) {
           return Response.json(
             { error: 'Comment access denied' },
             { status: 403 },
@@ -85,10 +82,7 @@ export const Route = createFileRoute('/api/comments/$id')({
           .where(eq(schema.issueComment.id, params.id))
         if (!existingComment) return notFound('Comment not found')
 
-        if (
-          existingComment.authorType === 'user' &&
-          existingComment.authorId !== session.user.id
-        ) {
+        if (existingComment.authorId !== session.user.id) {
           return Response.json(
             { error: 'Comment access denied' },
             { status: 403 },


### PR DESCRIPTION
**overview**

the comments endpoint (`/api/comments/$id`) let any authenticated user edit or delete another workspace's agent comments, even though the functionality is not exposed on the ui. the guard only checked ownership for `authorType === 'user'`, so agent-authored comments (authorType is 'agent') skipped the check entirely and had no workspace membership check either. any logged-in user could tamper with or remove ai comments from any team by id.

the comment id is uuid4 from crypto.randomUUID and is unguessable, but that does not stop the bug being valid: ids are not an authorization boundary, and any user who has seen an agent comment id (was a member, copied a link, received an inbox or notification payload) can act on it.

**fix**

change the ownership check in both put and delete to require `existingComment.authorId === session.user.id` unconditionally, for both user and agent comments. this makes agent comments immutable through the api (the author is the agent, never the session user), while preserving the existing behavior where a user can only edit their own comments.

- the only code that updates or deletes issue comments is this route itself. agents only create comments, they never edit or delete them.
- the ui never exposed edit or delete for agent comments anyway, so no feature is lost.
- no tests reference the handler.

**tests**

- reproduced the bug with a test (put returned 200, delete returned 204 for a cross-workspace user)
- after the fix both return 403
- typecheck and lint pass