### PR TITLE
fix(connectors): repair stale GitHub installations

### DIFF
--- a/apps/web/src/components/shell/workspace-layout.tsx
+++ b/apps/web/src/components/shell/workspace-layout.tsx
@@ -1,8 +1,15 @@
 import { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { CheckCircle2, CircleAlert } from 'lucide-react'
 import { useAuthStore } from '@garden/app-state/auth'
 import { useWorkspaceStore } from '@garden/app-state/workspace'
 import { Button } from '@garden/ui/components/ui/button'
+import {
+  Alert,
+  AlertAction,
+  AlertDescription,
+  AlertTitle,
+} from '@garden/ui/components/ui/alert'
 import { SidebarInset, SidebarProvider } from '@garden/ui/components/ui/sidebar'
 import { Skeleton } from '@garden/ui/components/ui/skeleton'
 import { SearchCommand } from '@/features/search'
@@ -10,14 +17,20 @@ import { ChatRuntimeProvider } from '@/features/chat/chat-runtime-provider'
 import { CreateWorkspaceModal } from '@/features/modals/create-workspace'
 import { SettingsDialog } from '@/features/settings'
 import { IssueDeepLinkListener } from '@/features/issues/components/issue-deep-link-listener'
+import { getConnectorCallbackEvent } from '@/lib/api/connections'
 import {
   agentListOptions,
   connectionListOptions,
   memberListOptions,
   skillListOptions,
+  workspaceKeys,
 } from '@/lib/workspace/queries'
 import { WorkspaceSidebar } from './sidebar'
-import { WorkspaceDockProvider, WorkspaceDockView } from './workspace-dock'
+import {
+  useRequiredWorkspaceDock,
+  WorkspaceDockProvider,
+  WorkspaceDockView,
+} from './workspace-dock'
 
 /**
  * Mount-only prefetch for workspace-wide caches.
@@ -83,7 +96,95 @@ function WorkspaceSetupState({ onCreate }: { onCreate: () => void }) {
   )
 }
 
+/** Shows connector callback outcomes at the workspace boundary where redirects land. */
+function ConnectorCallbackNotice({
+  connectorFlowId,
+  connectorId,
+  workspaceId,
+}: {
+  connectorFlowId?: string | null
+  connectorId?: string | null
+  workspaceId: string
+}) {
+  const [dismissed, setDismissed] = useState(false)
+  const dock = useRequiredWorkspaceDock()
+  const queryClient = useQueryClient()
+  const flowId = connectorFlowId?.trim() ?? ''
+  const callback = useQuery({
+    queryKey: ['connector-callback-event', flowId, connectorId ?? null],
+    queryFn: () =>
+      getConnectorCallbackEvent({ flowId, connectorId: connectorId ?? null }),
+    enabled: flowId.length > 0,
+    retry: false,
+    staleTime: Number.POSITIVE_INFINITY,
+  })
+
+  if (!flowId || dismissed) return null
+
+  const event = callback.data?.event
+  const failed = callback.isError || event?.status === 'error'
+  const title = callback.isPending
+    ? 'Finishing connection'
+    : failed
+      ? 'Connection needs attention'
+      : event?.status === 'degraded'
+        ? `${event.connectorLabel} needs attention`
+        : `${event?.connectorLabel ?? 'Connection'} connected`
+  const description = callback.isPending
+    ? 'Checking the provider callback status.'
+    : callback.isError
+      ? 'Open Connections to review the provider status and repair it.'
+      : (event?.message ?? 'Provider access is ready.')
+
+  const dismissNotice = () => {
+    setDismissed(true)
+    const url = new URL(window.location.href)
+    url.searchParams.delete('connector_flow')
+    url.searchParams.delete('connector_id')
+    window.history.replaceState(window.history.state, '', url.toString())
+  }
+
+  return (
+    <Alert
+      variant={failed ? 'destructive' : 'default'}
+      className="absolute top-3 right-3 z-50 w-[min(28rem,calc(100%-1.5rem))] bg-background/95 pr-28 shadow-lg backdrop-blur"
+    >
+      {failed || event?.status === 'degraded' ? (
+        <CircleAlert className="size-4" />
+      ) : (
+        <CheckCircle2 className="size-4" />
+      )}
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription>{description}</AlertDescription>
+      <AlertAction className="flex gap-1">
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={async () => {
+            await queryClient.invalidateQueries({
+              queryKey: workspaceKeys.connections(workspaceId),
+            })
+            dismissNotice()
+            dock.openPanel({
+              kind: 'capabilities',
+              title: 'Connections',
+              entityId: connectorId ?? event?.connectorId,
+            })
+          }}
+        >
+          Open
+        </Button>
+        <Button size="sm" variant="ghost" onClick={dismissNotice}>
+          Dismiss
+        </Button>
+      </AlertAction>
+    </Alert>
+  )
+}
+
 export function WorkspaceLayout({
+  connectorFlowId = null,
+  connectorId = null,
   issueId = null,
 }: {
   connectorFlowId?: string | null
@@ -113,6 +214,11 @@ export function WorkspaceLayout({
             <IssueDeepLinkListener
               workspaceId={activeWorkspaceId}
               issueId={issueId}
+            />
+            <ConnectorCallbackNotice
+              connectorFlowId={connectorFlowId}
+              connectorId={connectorId}
+              workspaceId={activeWorkspaceId}
             />
             <ChatRuntimeProvider>
               <WorkspaceSidebar

--- a/apps/web/src/features/connections/components/connections-page.tsx
+++ b/apps/web/src/features/connections/components/connections-page.tsx
@@ -278,7 +278,9 @@ export function ConnectionsPage({
         return
       }
       if (integration.providerId === 'github.com') {
-        window.location.assign('/api/github/install')
+        const url = new URL('/api/github/install', window.location.origin)
+        url.searchParams.set('connector_flow', crypto.randomUUID())
+        window.location.assign(url.toString())
         return
       }
       connectionMutation.mutate({ slug: integration.slug, action: 'connect' })
@@ -1095,6 +1097,9 @@ function ManageDrawerBody({
     (connection) => connection.owner === owner,
   )
   const connectedInScope = visibleConnections.length > 0
+  const githubNeedsRepair =
+    activeIntegration.providerId === 'github.com' &&
+    activeIntegration.status === 'degraded'
   const previewQuery = useQuery({
     queryKey: ['executor-tool-preview', entry.providerId, source],
     queryFn: () => previewIntegrationTools({ entry, source }),
@@ -1275,6 +1280,25 @@ function ManageDrawerBody({
       </DrawerHeader>
 
       <div className="flex-1 overflow-y-auto px-6 py-5">
+        {githubNeedsRepair ? (
+          <section className="mb-5 rounded-lg border border-amber-500/30 bg-amber-500/8 p-4">
+            <h3 className="text-sm font-semibold text-foreground">
+              GitHub installation needs repair
+            </h3>
+            <p className="mt-1 max-w-prose text-sm text-muted-foreground">
+              Reconnect the GitHub App to replace the stale installation without
+              changing repository access.
+            </p>
+            <Button
+              className="mt-3"
+              size="sm"
+              disabled={pending}
+              onClick={() => onConnect(activeIntegration)}
+            >
+              Repair GitHub App
+            </Button>
+          </section>
+        ) : null}
         <Tabs
           value={source}
           onValueChange={(value) => {

--- a/apps/web/src/lib/api/connections.ts
+++ b/apps/web/src/lib/api/connections.ts
@@ -7,6 +7,20 @@ import { getApiTransport } from './state'
 
 export type IntegrationAction = 'connect' | 'disconnect' | 'delete' | 'resync'
 
+const ConnectorCallbackEvent = Schema.Struct({
+  id: Schema.String,
+  connectorId: Schema.String,
+  connectorLabel: Schema.String,
+  status: Schema.Literals(['success', 'degraded', 'error']),
+  message: Schema.NullOr(Schema.String),
+})
+
+const ConnectorCallbackEventResponse = Schema.Struct({
+  event: ConnectorCallbackEvent,
+})
+
+export type ConnectorCallbackEventItem = typeof ConnectorCallbackEvent.Type
+
 /** Load and decode the complete Executor connections contract. */
 export async function listConnections(): Promise<ExecutorConnectionsSnapshotType> {
   const response = await getApiTransport().request<unknown>('/api/connections')
@@ -24,4 +38,17 @@ export function mutateConnection(
       body: JSON.stringify({ action }),
     },
   )
+}
+
+/** Loads the callback outcome referenced by the signed connector flow URL. */
+export async function getConnectorCallbackEvent(args: {
+  flowId: string
+  connectorId?: string | null
+}) {
+  const search = new URLSearchParams({ flow_id: args.flowId })
+  if (args.connectorId) search.set('connector_id', args.connectorId)
+  const response = await getApiTransport().request<unknown>(
+    `/api/connections/callback-events?${search.toString()}`,
+  )
+  return Schema.decodeUnknownPromise(ConnectorCallbackEventResponse)(response)
 }

--- a/apps/web/src/lib/server/github-app.ts
+++ b/apps/web/src/lib/server/github-app.ts
@@ -26,7 +26,8 @@ type GitHubAppEnv = Pick<
 
 type GitHubAppDatabase = Db
 
-function normalizeGitHubAppEnv(env: GitHubAppEnv) {
+/** Normalizes private keys stored as JSON-quoted Worker secrets before signing. */
+export function normalizeGitHubAppEnv(env: GitHubAppEnv) {
   const privateKey = env.GITHUB_APP_PRIVATE_KEY?.trim()
 
   return {

--- a/apps/web/src/routes/api/connections/$connectorId.ts
+++ b/apps/web/src/routes/api/connections/$connectorId.ts
@@ -236,10 +236,7 @@ export const Route = createFileRoute('/api/connections/$connectorId')({
             return notFound('GitHub App installation not found')
           }
 
-          if (
-            bodyResult.value.action === 'delete' ||
-            bodyResult.value.action === 'disconnect'
-          ) {
+          if (bodyResult.value.action === 'delete') {
             const uninstalled = await deleteGitHubAppInstallation({
               env: {
                 GITHUB_APP_ID: appEnv.GITHUB_APP_ID,
@@ -259,6 +256,12 @@ export const Route = createFileRoute('/api/connections/$connectorId')({
                 { status: 502 },
               )
             }
+          }
+
+          if (
+            bodyResult.value.action === 'delete' ||
+            bodyResult.value.action === 'disconnect'
+          ) {
             await db
               .delete(schema.githubAppInstallation)
               .where(
@@ -274,6 +277,7 @@ export const Route = createFileRoute('/api/connections/$connectorId')({
               properties: {
                 connector_id: 'github',
                 connection_kind: 'github_app',
+                action: bodyResult.value.action,
               },
             })
             return Response.json({ ok: true })

--- a/apps/web/src/routes/api/connections/-github-actions.integration.test.ts
+++ b/apps/web/src/routes/api/connections/-github-actions.integration.test.ts
@@ -1,0 +1,91 @@
+import type { AppRequestContext } from '@/lib/server/context'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Route } from './$connectorId'
+
+const mocks = vi.hoisted(() => ({
+  capturePostHogEvent: vi.fn(),
+  deleteGitHubAppInstallation: vi.fn(),
+  requireWorkspaceContext: vi.fn(),
+  requireWorkspacePermission: vi.fn(),
+}))
+
+vi.mock('@garden/connectors/github-app', () => ({
+  deleteGitHubAppInstallation: mocks.deleteGitHubAppInstallation,
+  getGitHubAppInstallation: vi.fn(),
+}))
+
+vi.mock('@/lib/server/control-plane', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/server/control-plane')>()
+  return {
+    ...actual,
+    requireWorkspaceContext: mocks.requireWorkspaceContext,
+  }
+})
+
+vi.mock('@/lib/server/workspace-permissions', () => ({
+  requireWorkspacePermission: mocks.requireWorkspacePermission,
+  workspacePermissions: {
+    connectionManage: { connection: ['manage'] },
+  },
+}))
+
+vi.mock('@/lib/posthog-server', () => ({
+  capturePostHogEvent: mocks.capturePostHogEvent,
+}))
+
+vi.mock('@/lib/server/env', () => ({ appEnv: {} }))
+
+function getPostHandler() {
+  const handlers = Route.options.server?.handlers
+  if (!handlers || typeof handlers === 'function' || !handlers.POST) {
+    throw new Error('Expected connection POST handler')
+  }
+  return handlers.POST
+}
+
+describe('GitHub connection actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.requireWorkspaceContext.mockResolvedValue({
+      workspaceId: 'workspace-id',
+      session: { user: { id: 'user-id' } },
+    })
+    mocks.requireWorkspacePermission.mockResolvedValue(null)
+  })
+
+  it('disconnects the workspace binding without uninstalling the organization app', async () => {
+    const limit = vi
+      .fn()
+      .mockResolvedValue([
+        { installationId: '155955068', accountLogin: 'Flow-Research' },
+      ])
+    const deleteWhere = vi.fn().mockResolvedValue(undefined)
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({ limit })),
+        })),
+      })),
+      delete: vi.fn(() => ({ where: deleteWhere })),
+    }
+    const request = new Request('https://garden.test/api/connections/github', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'disconnect' }),
+    })
+
+    const response = await getPostHandler()({
+      context: { db: async () => db } as unknown as AppRequestContext,
+      request,
+      params: { connectorId: 'github' },
+      pathname: '/api/connections/$connectorId',
+      next: () => ({ isNext: true, context: undefined }),
+    })
+
+    expect(response?.status).toBe(200)
+    await expect(response?.json()).resolves.toEqual({ ok: true })
+    expect(mocks.deleteGitHubAppInstallation).not.toHaveBeenCalled()
+    expect(deleteWhere).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/web/src/routes/api/github/-install.integration.test.ts
+++ b/apps/web/src/routes/api/github/-install.integration.test.ts
@@ -1,17 +1,24 @@
 import { Result } from 'better-result'
+import { GitHubAppAuthError } from '@garden/connectors/github-app'
 import type { AppRequestContext } from '@/lib/server/context'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Route } from './install'
 
 const mocks = vi.hoisted(() => ({
   getGitHubAppInstallation: vi.fn(),
+  createGitHubSetupState: vi.fn(async () => 'signed-state'),
   requireSession: vi.fn(),
   resolveWorkspaceId: vi.fn(),
 }))
 
-vi.mock('@garden/connectors/github-app', () => ({
-  getGitHubAppInstallation: mocks.getGitHubAppInstallation,
-}))
+vi.mock('@garden/connectors/github-app', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@garden/connectors/github-app')>()
+  return {
+    ...actual,
+    getGitHubAppInstallation: mocks.getGitHubAppInstallation,
+  }
+})
 
 vi.mock('@/lib/server/control-plane', async (importOriginal) => {
   const actual =
@@ -40,7 +47,7 @@ vi.mock('@/lib/server/github-app', () => ({
     appSlug: string
     state: string
   }) => `https://github.com/apps/${appSlug}/installations/new?state=${state}`,
-  createGitHubSetupState: vi.fn(async () => 'signed-state'),
+  createGitHubSetupState: mocks.createGitHubSetupState,
   normalizeGitHubAppEnv: (env: unknown) => env,
   resolveGitHubAppSlug: () => 'garden-ai-dev',
 }))
@@ -78,7 +85,13 @@ describe('GitHub install recovery', () => {
       })),
     }
     mocks.getGitHubAppInstallation.mockResolvedValue(
-      Result.err(new Error('Not Found')),
+      Result.err(
+        new GitHubAppAuthError({
+          code: 'token_request_failed',
+          status: 404,
+          message: 'Not Found',
+        }),
+      ),
     )
 
     const request = new Request(
@@ -98,5 +111,48 @@ describe('GitHub install recovery', () => {
     )
     expect(db.update).toHaveBeenCalledOnce()
     expect(updateWhere).toHaveBeenCalledOnce()
+  })
+
+  it('preserves a connected row when GitHub verification temporarily fails', async () => {
+    const limit = vi
+      .fn()
+      .mockResolvedValue([
+        { id: 'installation-row-id', installationId: 'installation-id' },
+      ])
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({ limit })),
+        })),
+      })),
+      update: vi.fn(),
+    }
+    mocks.getGitHubAppInstallation.mockResolvedValue(
+      Result.err(
+        new GitHubAppAuthError({
+          code: 'token_request_failed',
+          status: 503,
+          message: 'Service Unavailable',
+        }),
+      ),
+    )
+
+    const request = new Request(
+      'https://garden.test/api/github/install?connector_flow=flow-id',
+    )
+    const response = await getHandler()({
+      context: { db: async () => db } as unknown as AppRequestContext,
+      request,
+      params: {},
+      pathname: '/api/github/install',
+      next: () => ({ isNext: true, context: undefined }),
+    })
+
+    expect(response?.status).toBe(502)
+    await expect(response?.json()).resolves.toEqual({
+      error: 'Unable to verify the GitHub installation. Try again.',
+    })
+    expect(db.update).not.toHaveBeenCalled()
+    expect(mocks.createGitHubSetupState).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/routes/api/github/-install.integration.test.ts
+++ b/apps/web/src/routes/api/github/-install.integration.test.ts
@@ -1,0 +1,102 @@
+import { Result } from 'better-result'
+import type { AppRequestContext } from '@/lib/server/context'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Route } from './install'
+
+const mocks = vi.hoisted(() => ({
+  getGitHubAppInstallation: vi.fn(),
+  requireSession: vi.fn(),
+  resolveWorkspaceId: vi.fn(),
+}))
+
+vi.mock('@garden/connectors/github-app', () => ({
+  getGitHubAppInstallation: mocks.getGitHubAppInstallation,
+}))
+
+vi.mock('@/lib/server/control-plane', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/server/control-plane')>()
+  return {
+    ...actual,
+    requireSession: mocks.requireSession,
+    resolveWorkspaceId: mocks.resolveWorkspaceId,
+  }
+})
+
+vi.mock('@/lib/server/env', () => ({
+  appEnv: {
+    BETTER_AUTH_SECRET: 'test-secret',
+    GITHUB_APP_ID: '3547700',
+    GITHUB_APP_PRIVATE_KEY: 'test-private-key',
+    GITHUB_APP_SLUG: 'garden-ai-dev',
+  },
+}))
+
+vi.mock('@/lib/server/github-app', () => ({
+  buildGitHubAppInstallUrl: ({
+    appSlug,
+    state,
+  }: {
+    appSlug: string
+    state: string
+  }) => `https://github.com/apps/${appSlug}/installations/new?state=${state}`,
+  createGitHubSetupState: vi.fn(async () => 'signed-state'),
+  normalizeGitHubAppEnv: (env: unknown) => env,
+  resolveGitHubAppSlug: () => 'garden-ai-dev',
+}))
+
+function getHandler() {
+  const handlers = Route.options.server?.handlers
+  if (!handlers || typeof handlers === 'function' || !handlers.GET) {
+    throw new Error('Expected GitHub install GET handler')
+  }
+  return handlers.GET
+}
+
+describe('GitHub install recovery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.requireSession.mockResolvedValue({ user: { id: 'user-id' } })
+    mocks.resolveWorkspaceId.mockResolvedValue('workspace-id')
+  })
+
+  it('marks a stale connected row degraded and starts a signed repair flow', async () => {
+    const limit = vi
+      .fn()
+      .mockResolvedValue([
+        { id: 'installation-row-id', installationId: 'old-installation-id' },
+      ])
+    const updateWhere = vi.fn().mockResolvedValue(undefined)
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({ limit })),
+        })),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn(() => ({ where: updateWhere })),
+      })),
+    }
+    mocks.getGitHubAppInstallation.mockResolvedValue(
+      Result.err(new Error('Not Found')),
+    )
+
+    const request = new Request(
+      'https://garden.test/api/github/install?connector_flow=flow-id',
+    )
+    const response = await getHandler()({
+      context: { db: async () => db } as unknown as AppRequestContext,
+      request,
+      params: {},
+      pathname: '/api/github/install',
+      next: () => ({ isNext: true, context: undefined }),
+    })
+
+    expect(response?.status).toBe(302)
+    expect(response?.headers.get('location')).toBe(
+      'https://github.com/apps/garden-ai-dev/installations/new?state=signed-state',
+    )
+    expect(db.update).toHaveBeenCalledOnce()
+    expect(updateWhere).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/web/src/routes/api/github/-install.integration.test.ts
+++ b/apps/web/src/routes/api/github/-install.integration.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   createGitHubSetupState: vi.fn(async () => 'signed-state'),
   requireSession: vi.fn(),
   resolveWorkspaceId: vi.fn(),
+  requireWorkspacePermission: vi.fn(),
 }))
 
 vi.mock('@garden/connectors/github-app', async (importOriginal) => {
@@ -39,6 +40,13 @@ vi.mock('@/lib/server/env', () => ({
   },
 }))
 
+vi.mock('@/lib/server/workspace-permissions', () => ({
+  requireWorkspacePermission: mocks.requireWorkspacePermission,
+  workspacePermissions: {
+    connectionManage: { connection: ['update'] },
+  },
+}))
+
 vi.mock('@/lib/server/github-app', () => ({
   buildGitHubAppInstallUrl: ({
     appSlug,
@@ -65,6 +73,39 @@ describe('GitHub install recovery', () => {
     vi.clearAllMocks()
     mocks.requireSession.mockResolvedValue({ user: { id: 'user-id' } })
     mocks.resolveWorkspaceId.mockResolvedValue('workspace-id')
+    mocks.requireWorkspacePermission.mockResolvedValue(null)
+  })
+
+  it('refuses installation changes without connection management permission', async () => {
+    const forbidden = Response.json({ error: 'Forbidden' }, { status: 403 })
+    const db = {
+      select: vi.fn(),
+      update: vi.fn(),
+    }
+    mocks.requireWorkspacePermission.mockResolvedValue(forbidden)
+
+    const request = new Request(
+      'https://garden.test/api/github/install?connector_flow=flow-id',
+    )
+    const response = await getHandler()({
+      context: { db: async () => db } as unknown as AppRequestContext,
+      request,
+      params: {},
+      pathname: '/api/github/install',
+      next: () => ({ isNext: true, context: undefined }),
+    })
+
+    expect(response).toBe(forbidden)
+    expect(mocks.requireWorkspacePermission).toHaveBeenCalledWith({
+      appContext: expect.anything(),
+      request,
+      workspaceId: 'workspace-id',
+      permissions: { connection: ['update'] },
+    })
+    expect(db.select).not.toHaveBeenCalled()
+    expect(db.update).not.toHaveBeenCalled()
+    expect(mocks.getGitHubAppInstallation).not.toHaveBeenCalled()
+    expect(mocks.createGitHubSetupState).not.toHaveBeenCalled()
   })
 
   it('marks a stale connected row degraded and starts a signed repair flow', async () => {

--- a/apps/web/src/routes/api/github/install.ts
+++ b/apps/web/src/routes/api/github/install.ts
@@ -10,6 +10,7 @@ import {
 } from '@/lib/server/control-plane'
 import { schema, type Db } from '@/lib/server/db'
 import { appEnv } from '@/lib/server/env'
+import { captureApiFailure } from '@/lib/server/api-logging'
 import {
   connectorCallbackSearchParams,
   recordConnectorCallbackEvent,
@@ -112,7 +113,28 @@ export const Route = createFileRoute('/api/github/install')({
           })
         }
 
-        if (connectedInstallation && verifiedInstallation?.isErr()) {
+        if (
+          connectedInstallation &&
+          verifiedInstallation?.isErr() &&
+          verifiedInstallation.error.status !== 404
+        ) {
+          await captureApiFailure({
+            request,
+            event: 'github.installation.verify_failed',
+            error: verifiedInstallation.error,
+            level: 'warn',
+          })
+          return Response.json(
+            { error: 'Unable to verify the GitHub installation. Try again.' },
+            { status: 502 },
+          )
+        }
+
+        if (
+          connectedInstallation &&
+          verifiedInstallation?.isErr() &&
+          verifiedInstallation.error.status === 404
+        ) {
           await db
             .update(schema.githubAppInstallation)
             .set({ status: 'degraded', updatedAt: new Date() })

--- a/apps/web/src/routes/api/github/install.ts
+++ b/apps/web/src/routes/api/github/install.ts
@@ -17,8 +17,10 @@ import {
 import {
   buildGitHubAppInstallUrl,
   createGitHubSetupState,
+  normalizeGitHubAppEnv,
   resolveGitHubAppSlug,
 } from '@/lib/server/github-app'
+import { getGitHubAppInstallation } from '@garden/connectors/github-app'
 
 function readConnectorFlowId(request: Request) {
   const value = new URL(request.url).searchParams.get('connector_flow')?.trim()
@@ -39,12 +41,15 @@ function redirectToGitHubPanel(request: Request, flowId?: string | null) {
 
 type GitHubInstallDb = Db
 
-async function hasConnectedGitHubInstall(args: {
+async function getConnectedGitHubInstall(args: {
   db: GitHubInstallDb
   workspaceId: string
 }) {
   const [installation] = await args.db
-    .select({ id: schema.githubAppInstallation.id })
+    .select({
+      id: schema.githubAppInstallation.id,
+      installationId: schema.githubAppInstallation.installationId,
+    })
     .from(schema.githubAppInstallation)
     .where(
       and(
@@ -54,7 +59,7 @@ async function hasConnectedGitHubInstall(args: {
     )
     .limit(1)
 
-  return Boolean(installation)
+  return installation ?? null
 }
 
 export const Route = createFileRoute('/api/github/install')({
@@ -70,7 +75,18 @@ export const Route = createFileRoute('/api/github/install')({
         const flowId = readConnectorFlowId(request)
         const db = await appContext.db()
 
-        if (await hasConnectedGitHubInstall({ db, workspaceId })) {
+        const connectedInstallation = await getConnectedGitHubInstall({
+          db,
+          workspaceId,
+        })
+        const verifiedInstallation = connectedInstallation
+          ? await getGitHubAppInstallation({
+              env: normalizeGitHubAppEnv(appEnv),
+              installationId: connectedInstallation.installationId,
+            })
+          : null
+
+        if (connectedInstallation && verifiedInstallation?.isOk()) {
           const event = await recordConnectorCallbackEvent({
             db,
             userId: session.user.id,
@@ -94,6 +110,15 @@ export const Route = createFileRoute('/api/github/install')({
                   ),
               }),
           })
+        }
+
+        if (connectedInstallation && verifiedInstallation?.isErr()) {
+          await db
+            .update(schema.githubAppInstallation)
+            .set({ status: 'degraded', updatedAt: new Date() })
+            .where(
+              eq(schema.githubAppInstallation.id, connectedInstallation.id),
+            )
         }
 
         return new Response(null, {

--- a/apps/web/src/routes/api/github/install.ts
+++ b/apps/web/src/routes/api/github/install.ts
@@ -8,6 +8,10 @@ import {
   resolveWorkspaceId,
   unauthorized,
 } from '@/lib/server/control-plane'
+import {
+  requireWorkspacePermission,
+  workspacePermissions,
+} from '@/lib/server/workspace-permissions'
 import { schema, type Db } from '@/lib/server/db'
 import { appEnv } from '@/lib/server/env'
 import { captureApiFailure } from '@/lib/server/api-logging'
@@ -73,6 +77,15 @@ export const Route = createFileRoute('/api/github/install')({
 
         const workspaceId = await resolveWorkspaceId(request, session.user.id)
         if (!workspaceId) return badRequest('Workspace not found')
+
+        const permission = await requireWorkspacePermission({
+          appContext,
+          request,
+          workspaceId,
+          permissions: workspacePermissions.connectionManage,
+        })
+        if (permission) return permission
+
         const flowId = readConnectorFlowId(request)
         const db = await appContext.db()
 


### PR DESCRIPTION
## Summary
- verify stored GitHub installations before treating them as connected
- add a signed repair flow and callback notice for degraded installations
- separate local disconnect from organization-wide GitHub App uninstall

## Verification
- focused GitHub connector tests passed: 2 files, 2 tests
- web typecheck passed
- web lint passed
- full web suite passed 50 files and 192 tests; one unrelated Testcontainers suite could not run before Docker was restored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer status notifications for connector setup, including pending, successful, degraded, and failed outcomes.
  * Added actions to dismiss setup notices or open the Connections panel for follow-up.
  * Added a GitHub repair option when an installation is degraded.

* **Bug Fixes**
  * GitHub installations are now verified during setup, with stale installations marked for repair.
  * Disconnecting GitHub removes the workspace connection without uninstalling the GitHub App.
  * Added permission checks to protect GitHub connection management actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->