### PR TITLE
fix: preserve scroll position when user scrolls up during agent thinking

### DIFF
--- a/apps/web/src/components/ai-elements/conversation-scroll.test.tsx
+++ b/apps/web/src/components/ai-elements/conversation-scroll.test.tsx
@@ -1,0 +1,197 @@
+import { forwardRef, useImperativeHandle, useRef } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { act, render, screen } from '@testing-library/react'
+
+/**
+ * Regression tests for chat scroll behavior during agent streaming.
+ *
+ * The fix binds `maintainScrollAtEnd` to React `isAtBottom` state instead of
+ * hardcoded `true`. This prevents auto-scroll from re-engaging when the user
+ * scrolls up during streaming — even after content growth brings them back
+ * within LegendList's internal threshold.
+ *
+ * LegendList's internal `isAtEnd` is recomputed on every scroll/layout and is
+ * sufficient to stop auto-scroll while the user is away from the end. But with
+ * `maintainScrollAtEnd={true}`, auto-scroll re-engages the instant `isAtEnd`
+ * flips back to true (content grew past the user's position). The React state
+ * acts as a persistent user-intent latch: it only returns true when the user
+ * explicitly scrolls to the bottom or clicks "Scroll to bottom".
+ */
+
+type MockListHandle = {
+  /** Simulate a scroll event. Calls the onScroll prop, which triggers
+   *  updateStickiness → reads getState().isAtEnd → sets isAtBottom state. */
+  simulateScroll: (isAtEnd: boolean) => void
+}
+
+let lastMaintainScrollAtEnd: boolean | undefined
+let onScrollRef: (() => void) | undefined
+
+const MockLegendList = forwardRef<MockListHandle, any>(function MockLegendList(
+  { data, maintainScrollAtEnd, onScroll },
+  ref,
+) {
+  lastMaintainScrollAtEnd = maintainScrollAtEnd
+  onScrollRef = onScroll
+
+  useImperativeHandle(ref, () => ({
+    getState: () => ({ isAtEnd: mockGetStateIsAtEnd }),
+    simulateScroll(isAtEnd: boolean) {
+      mockGetStateIsAtEnd = isAtEnd
+      onScroll?.()
+    },
+  }))
+
+  return (
+    <div data-testid="mock-list">
+      <div data-testid="maintain-scroll">
+        {String(maintainScrollAtEnd)}
+      </div>
+      {data?.map((item: any) => (
+        <div key={item.key}>{item.key}</div>
+      ))}
+    </div>
+  )
+})
+
+// Shared state for mock getState().isAtEnd
+let mockGetStateIsAtEnd = true
+
+vi.mock('@legendapp/list/react', () => ({
+  LegendList: MockLegendList,
+}))
+
+const { Conversation } = await import('./conversation')
+
+function renderConversation() {
+  const ref = { current: null as unknown as MockListHandle }
+  const result = render(
+    <Conversation
+      data={[{ id: '1' }, { id: '2' }, { id: '3' }]}
+      getItemKey={(item: any) => item.id}
+      renderItem={({ item }: { item: any }) => <div>{item.id}</div>}
+    >
+      <span data-testid="children">child content</span>
+    </Conversation>,
+  )
+
+  // Grab the ref from the mocked LegendList. The component renders
+  // <LegendList ref={listRef} ...>, and our mock exposes simulateScroll.
+  // We need to extract the ref. Since LegendList is mocked inline and
+  // useImperativeHandle binds to the forwarded ref, we can access it
+  // through the component's internal ref by rendering a helper.
+  //
+  // Alternative: we modify the mock to expose the ref globally.
+  return { ...result, ref }
+}
+
+describe('Conversation scroll stickiness', () => {
+  it('starts with maintainScrollAtEnd=true (initial isAtBottom state)', () => {
+    mockGetStateIsAtEnd = true
+    renderConversation()
+    expect(lastMaintainScrollAtEnd).toBe(true)
+  })
+
+  it('disables auto-scroll when user scrolls up (isAtEnd becomes false)', () => {
+    mockGetStateIsAtEnd = true
+    const { unmount } = renderConversation()
+    expect(lastMaintainScrollAtEnd).toBe(true)
+
+    // Simulate user scrolling up: LegendList's isAtEnd flips to false.
+    // The onScroll callback (updateStickiness) reads getState().isAtEnd
+    // and sets React isAtBottom state to false, which feeds maintainScrollAtEnd.
+    // This requires two renders: one for the state update, one for the prop.
+    // We use act() to flush the state update.
+    act(() => {
+      mockGetStateIsAtEnd = false
+      // Trigger the onScroll callback that updateStickiness wraps.
+      // We need to call the mock's simulateScroll, but we don't have the ref.
+      // Instead, we access the mock's onScroll callback directly.
+      onScrollRef?.()
+    })
+
+    // After state update: isAtBottom=false → maintainScrollAtEnd=false
+    expect(lastMaintainScrollAtEnd).toBe(false)
+
+    unmount()
+  })
+
+  it('re-enables auto-scroll when user scrolls back to bottom', () => {
+    mockGetStateIsAtEnd = true
+    const { unmount } = renderConversation()
+
+    // Scroll away
+    act(() => {
+      mockGetStateIsAtEnd = false
+      onScrollRef?.()
+    })
+    expect(lastMaintainScrollAtEnd).toBe(false)
+
+    // Scroll back to bottom
+    act(() => {
+      mockGetStateIsAtEnd = true
+      onScrollRef?.()
+    })
+    expect(lastMaintainScrollAtEnd).toBe(true)
+
+    unmount()
+  })
+
+  it('maintains disabled auto-scroll when streaming adds content while scrolled up', () => {
+    mockGetStateIsAtEnd = true
+    const { rerender, unmount } = renderConversation()
+
+    // Scroll up
+    act(() => {
+      mockGetStateIsAtEnd = false
+      onScrollRef?.()
+    })
+    expect(lastMaintainScrollAtEnd).toBe(false)
+
+    // Simulate streaming: data grows but user is still scrolled up.
+    // LegendList's isAtEnd stays false because the user hasn't scrolled down.
+    // maintainScrollAtEnd should remain false — no auto-scroll.
+    mockGetStateIsAtEnd = false
+    act(() => {
+      rerender(
+        <Conversation
+          data={[{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }]}
+          getItemKey={(item: any) => item.id}
+          renderItem={({ item }: { item: any }) => <div>{item.id}</div>}
+        >
+          <span data-testid="children">child content</span>
+        </Conversation>,
+      )
+    })
+
+    // Data grew but isAtEnd is still false (user scrolled up) → no auto-scroll
+    expect(lastMaintainScrollAtEnd).toBe(false)
+
+    unmount()
+  })
+
+  it('keeps auto-scroll pinned when at bottom during streaming', () => {
+    mockGetStateIsAtEnd = true
+    const { rerender, unmount } = renderConversation()
+    expect(lastMaintainScrollAtEnd).toBe(true)
+
+    // Simulate streaming while at bottom: data grows, isAtEnd stays true
+    mockGetStateIsAtEnd = true
+    act(() => {
+      rerender(
+        <Conversation
+          data={[{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }, { id: '5' }]}
+          getItemKey={(item: any) => item.id}
+          renderItem={({ item }: { item: any }) => <div>{item.id}</div>}
+        >
+          <span data-testid="children">child content</span>
+        </Conversation>,
+      )
+    })
+
+    // Still at bottom → maintainScrollAtEnd stays true
+    expect(lastMaintainScrollAtEnd).toBe(true)
+
+    unmount()
+  })
+})

--- a/apps/web/src/components/ai-elements/conversation-scroll.test.tsx
+++ b/apps/web/src/components/ai-elements/conversation-scroll.test.tsx
@@ -1,52 +1,26 @@
-import { forwardRef, useImperativeHandle, useRef } from 'react'
+import { forwardRef, useImperativeHandle } from 'react'
 import { describe, expect, it, vi } from 'vitest'
-import { act, render, screen } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 
-/**
- * Regression tests for chat scroll behavior during agent streaming.
- *
- * The fix binds `maintainScrollAtEnd` to React `isAtBottom` state instead of
- * hardcoded `true`. This prevents auto-scroll from re-engaging when the user
- * scrolls up during streaming — even after content growth brings them back
- * within LegendList's internal threshold.
- *
- * LegendList's internal `isAtEnd` is recomputed on every scroll/layout and is
- * sufficient to stop auto-scroll while the user is away from the end. But with
- * `maintainScrollAtEnd={true}`, auto-scroll re-engages the instant `isAtEnd`
- * flips back to true (content grew past the user's position). The React state
- * acts as a persistent user-intent latch: it only returns true when the user
- * explicitly scrolls to the bottom or clicks "Scroll to bottom".
- */
-
-type MockListHandle = {
-  /** Simulate a scroll event. Calls the onScroll prop, which triggers
-   *  updateStickiness → reads getState().isAtEnd → sets isAtBottom state. */
-  simulateScroll: (isAtEnd: boolean) => void
-}
-
-let lastMaintainScrollAtEnd: boolean | undefined
+let mockIsAtEnd = true
+let scrollToEndCalls: Array<{ animated: boolean }> = []
 let onScrollRef: (() => void) | undefined
 
-const MockLegendList = forwardRef<MockListHandle, any>(function MockLegendList(
+const MockLegendList = forwardRef<any, any>(function MockLegendList(
   { data, maintainScrollAtEnd, onScroll },
   ref,
 ) {
-  lastMaintainScrollAtEnd = maintainScrollAtEnd
   onScrollRef = onScroll
 
   useImperativeHandle(ref, () => ({
-    getState: () => ({ isAtEnd: mockGetStateIsAtEnd }),
-    simulateScroll(isAtEnd: boolean) {
-      mockGetStateIsAtEnd = isAtEnd
-      onScroll?.()
+    getState: () => ({ isAtEnd: mockIsAtEnd }),
+    scrollToEnd(opts?: { animated?: boolean }) {
+      scrollToEndCalls.push({ animated: opts?.animated ?? true })
     },
   }))
 
   return (
-    <div data-testid="mock-list">
-      <div data-testid="maintain-scroll">
-        {String(maintainScrollAtEnd)}
-      </div>
+    <div>
       {data?.map((item: any) => (
         <div key={item.key}>{item.key}</div>
       ))}
@@ -54,143 +28,200 @@ const MockLegendList = forwardRef<MockListHandle, any>(function MockLegendList(
   )
 })
 
-// Shared state for mock getState().isAtEnd
-let mockGetStateIsAtEnd = true
-
 vi.mock('@legendapp/list/react', () => ({
   LegendList: MockLegendList,
 }))
 
 const { Conversation } = await import('./conversation')
 
-function renderConversation() {
-  const ref = { current: null as unknown as MockListHandle }
-  const result = render(
-    <Conversation
-      data={[{ id: '1' }, { id: '2' }, { id: '3' }]}
-      getItemKey={(item: any) => item.id}
-      renderItem={({ item }: { item: any }) => <div>{item.id}</div>}
-    >
-      <span data-testid="children">child content</span>
-    </Conversation>,
+function flushRAF() {
+  return act(
+    () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
   )
+}
 
-  // Grab the ref from the mocked LegendList. The component renders
-  // <LegendList ref={listRef} ...>, and our mock exposes simulateScroll.
-  // We need to extract the ref. Since LegendList is mocked inline and
-  // useImperativeHandle binds to the forwarded ref, we can access it
-  // through the component's internal ref by rendering a helper.
-  //
-  // Alternative: we modify the mock to expose the ref globally.
-  return { ...result, ref }
+function simulateScrollToTop() {
+  mockIsAtEnd = false
+  act(() => {
+    onScrollRef?.()
+  })
+}
+
+function simulateScrollToBottom() {
+  mockIsAtEnd = true
+  act(() => {
+    onScrollRef?.()
+  })
 }
 
 describe('Conversation scroll stickiness', () => {
-  it('starts with maintainScrollAtEnd=true (initial isAtBottom state)', () => {
-    mockGetStateIsAtEnd = true
-    renderConversation()
-    expect(lastMaintainScrollAtEnd).toBe(true)
-  })
+  it('staying at bottom: auto-scrolls during streaming', async () => {
+    mockIsAtEnd = true
+    scrollToEndCalls = []
+    const { rerender, unmount } = render(
+      <Conversation
+        data={[{ id: 'user-1' }]}
+        getItemKey={(item: any) => item.id}
+        renderItem={({ item }: { item: any }) => <div>{item.id}</div>}
+      />,
+    )
+    scrollToEndCalls = []
 
-  it('disables auto-scroll when user scrolls up (isAtEnd becomes false)', () => {
-    mockGetStateIsAtEnd = true
-    const { unmount } = renderConversation()
-    expect(lastMaintainScrollAtEnd).toBe(true)
-
-    // Simulate user scrolling up: LegendList's isAtEnd flips to false.
-    // The onScroll callback (updateStickiness) reads getState().isAtEnd
-    // and sets React isAtBottom state to false, which feeds maintainScrollAtEnd.
-    // This requires two renders: one for the state update, one for the prop.
-    // We use act() to flush the state update.
-    act(() => {
-      mockGetStateIsAtEnd = false
-      // Trigger the onScroll callback that updateStickiness wraps.
-      // We need to call the mock's simulateScroll, but we don't have the ref.
-      // Instead, we access the mock's onScroll callback directly.
-      onScrollRef?.()
-    })
-
-    // After state update: isAtBottom=false → maintainScrollAtEnd=false
-    expect(lastMaintainScrollAtEnd).toBe(false)
-
-    unmount()
-  })
-
-  it('re-enables auto-scroll when user scrolls back to bottom', () => {
-    mockGetStateIsAtEnd = true
-    const { unmount } = renderConversation()
-
-    // Scroll away
-    act(() => {
-      mockGetStateIsAtEnd = false
-      onScrollRef?.()
-    })
-    expect(lastMaintainScrollAtEnd).toBe(false)
-
-    // Scroll back to bottom
-    act(() => {
-      mockGetStateIsAtEnd = true
-      onScrollRef?.()
-    })
-    expect(lastMaintainScrollAtEnd).toBe(true)
-
-    unmount()
-  })
-
-  it('maintains disabled auto-scroll when streaming adds content while scrolled up', () => {
-    mockGetStateIsAtEnd = true
-    const { rerender, unmount } = renderConversation()
-
-    // Scroll up
-    act(() => {
-      mockGetStateIsAtEnd = false
-      onScrollRef?.()
-    })
-    expect(lastMaintainScrollAtEnd).toBe(false)
-
-    // Simulate streaming: data grows but user is still scrolled up.
-    // LegendList's isAtEnd stays false because the user hasn't scrolled down.
-    // maintainScrollAtEnd should remain false — no auto-scroll.
-    mockGetStateIsAtEnd = false
     act(() => {
       rerender(
         <Conversation
-          data={[{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }]}
+          data={[{ id: 'user-1' }, { id: 'pending' }]}
           getItemKey={(item: any) => item.id}
           renderItem={({ item }: { item: any }) => <div>{item.id}</div>}
-        >
-          <span data-testid="children">child content</span>
-        </Conversation>,
+        />,
       )
     })
+    await flushRAF()
+    expect(scrollToEndCalls.length).toBe(1)
 
-    // Data grew but isAtEnd is still false (user scrolled up) → no auto-scroll
-    expect(lastMaintainScrollAtEnd).toBe(false)
+    scrollToEndCalls = []
+    act(() => {
+      rerender(
+        <Conversation
+          data={[
+            { id: 'user-1' },
+            { id: 'assistant-1', parts: [{ type: 'text', text: 'Hello' }] },
+          ]}
+          getItemKey={(item: any) => item.id}
+          renderItem={({ item }: { item: any }) => <div>{item.id}</div>}
+        />,
+      )
+    })
+    await flushRAF()
+    expect(scrollToEndCalls.length).toBe(1)
+
+    scrollToEndCalls = []
+    act(() => {
+      rerender(
+        <Conversation
+          data={[
+            { id: 'user-1' },
+            {
+              id: 'assistant-1',
+              parts: [{ type: 'text', text: 'Hello world this is streaming' }],
+            },
+          ]}
+          getItemKey={(item: any) => item.id}
+          renderItem={({ item }: { item: any }) => <div>{item.id}</div>}
+        />,
+      )
+    })
+    await flushRAF()
+    expect(scrollToEndCalls.length).toBe(1)
 
     unmount()
   })
 
-  it('keeps auto-scroll pinned when at bottom during streaming', () => {
-    mockGetStateIsAtEnd = true
-    const { rerender, unmount } = renderConversation()
-    expect(lastMaintainScrollAtEnd).toBe(true)
+  it('scrolling up: position stays during streaming', async () => {
+    mockIsAtEnd = true
+    scrollToEndCalls = []
+    const { rerender, unmount } = render(
+      <Conversation
+        data={[{ id: 'user-1' }]}
+        getItemKey={(item: any) => item.id}
+        renderItem={({ item }: { item: any }) => <div>{item.id}</div>}
+      />,
+    )
+    scrollToEndCalls = []
 
-    // Simulate streaming while at bottom: data grows, isAtEnd stays true
-    mockGetStateIsAtEnd = true
+    simulateScrollToTop()
+
     act(() => {
       rerender(
         <Conversation
-          data={[{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }, { id: '5' }]}
+          data={[{ id: 'user-1' }, { id: 'pending' }]}
           getItemKey={(item: any) => item.id}
           renderItem={({ item }: { item: any }) => <div>{item.id}</div>}
-        >
-          <span data-testid="children">child content</span>
-        </Conversation>,
+        />,
       )
     })
+    await flushRAF()
+    expect(scrollToEndCalls).toEqual([])
 
-    // Still at bottom → maintainScrollAtEnd stays true
-    expect(lastMaintainScrollAtEnd).toBe(true)
+    act(() => {
+      rerender(
+        <Conversation
+          data={[
+            { id: 'user-1' },
+            { id: 'assistant-1', parts: [{ type: 'text', text: 'Hello' }] },
+          ]}
+          getItemKey={(item: any) => item.id}
+          renderItem={({ item }: { item: any }) => <div>{item.id}</div>}
+        />,
+      )
+    })
+    await flushRAF()
+    expect(scrollToEndCalls).toEqual([])
+
+    act(() => {
+      rerender(
+        <Conversation
+          data={[
+            { id: 'user-1' },
+            {
+              id: 'assistant-1',
+              parts: [{ type: 'text', text: 'Hello world this is streaming' }],
+            },
+          ]}
+          getItemKey={(item: any) => item.id}
+          renderItem={({ item }: { item: any }) => <div>{item.id}</div>}
+        />,
+      )
+    })
+    await flushRAF()
+    expect(scrollToEndCalls).toEqual([])
+
+    unmount()
+  })
+
+  it('scroll back to bottom re-enables auto-scroll', async () => {
+    mockIsAtEnd = true
+    scrollToEndCalls = []
+    const { rerender, unmount } = render(
+      <Conversation
+        data={[{ id: 'user-1' }]}
+        getItemKey={(item: any) => item.id}
+        renderItem={({ item }: { item: any }) => <div>{item.id}</div>}
+      />,
+    )
+    scrollToEndCalls = []
+
+    simulateScrollToTop()
+
+    act(() => {
+      rerender(
+        <Conversation
+          data={[{ id: 'user-1' }, { id: 'pending' }]}
+          getItemKey={(item: any) => item.id}
+          renderItem={({ item }: { item: any }) => <div>{item.id}</div>}
+        />,
+      )
+    })
+    await flushRAF()
+    expect(scrollToEndCalls).toEqual([])
+
+    simulateScrollToBottom()
+
+    scrollToEndCalls = []
+    act(() => {
+      rerender(
+        <Conversation
+          data={[
+            { id: 'user-1' },
+            { id: 'assistant-1', parts: [{ type: 'text', text: 'Response' }] },
+          ]}
+          getItemKey={(item: any) => item.id}
+          renderItem={({ item }: { item: any }) => <div>{item.id}</div>}
+        />,
+      )
+    })
+    await flushRAF()
+    expect(scrollToEndCalls.length).toBe(1)
 
     unmount()
   })

--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -66,10 +66,16 @@ export function Conversation<TItem>({
 }: ConversationProps<TItem>) {
   const listRef = useRef<LegendListRef | null>(null)
   const [isAtBottom, setIsAtBottom] = useState(true)
+  const userScrolledUp = useRef(false)
+  const touchStartY = useRef(0)
 
   const updateStickiness = useCallback(() => {
     const state = listRef.current?.getState?.()
     if (!state) return
+    if (userScrolledUp.current) {
+      if (state.isAtEnd) userScrolledUp.current = false
+      return
+    }
     setIsAtBottom((current) =>
       current === state.isAtEnd ? current : state.isAtEnd,
     )
@@ -77,6 +83,7 @@ export function Conversation<TItem>({
 
   const scrollToBottom = useCallback(() => {
     listRef.current?.scrollToEnd?.({ animated: true })
+    userScrolledUp.current = false
     setIsAtBottom(true)
   }, [])
 
@@ -112,6 +119,10 @@ export function Conversation<TItem>({
 
   const handleWheel = useCallback(
     (event: ReactWheelEvent<HTMLDivElement>) => {
+      if (event.deltaY < 0) {
+        userScrolledUp.current = true
+        setIsAtBottom(false)
+      }
       onWheel?.(event)
     },
     [onWheel],
@@ -119,9 +130,21 @@ export function Conversation<TItem>({
 
   const handleTouchStart = useCallback(
     (event: ReactTouchEvent<HTMLDivElement>) => {
+      touchStartY.current = event.touches[0]!.clientY
       onTouchStart?.(event)
     },
     [onTouchStart],
+  )
+
+  const handleTouchMove = useCallback(
+    (event: ReactTouchEvent<HTMLDivElement>) => {
+      const dy = event.touches[0]!.clientY - touchStartY.current
+      if (dy > 10) {
+        userScrolledUp.current = true
+        setIsAtBottom(false)
+      }
+    },
+    [],
   )
 
   const contextValue = useMemo(
@@ -135,6 +158,7 @@ export function Conversation<TItem>({
         role="log"
         {...props}
         onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
         onWheel={handleWheel}
         className={cn('relative min-h-0 flex-1 overflow-hidden', className)}
       >

--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -3,16 +3,12 @@ import { cn } from '@garden/ui/lib/utils'
 import { LegendList, type LegendListRef } from '@legendapp/list/react'
 import type { UIMessage } from 'ai'
 import { ChevronDownIcon, DownloadIcon } from 'lucide-react'
-import type {
-  ComponentProps,
-  ReactNode,
-  TouchEvent as ReactTouchEvent,
-  WheelEvent as ReactWheelEvent,
-} from 'react'
+import type { ComponentProps, ReactNode } from 'react'
 import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -59,23 +55,17 @@ export function Conversation<TItem>({
   estimateItemSize = 90,
   getItemKey,
   initialContainerPoolRatio,
-  onTouchStart,
-  onWheel,
   renderItem: renderDataItem,
   ...props
 }: ConversationProps<TItem>) {
   const listRef = useRef<LegendListRef | null>(null)
   const [isAtBottom, setIsAtBottom] = useState(true)
-  const userScrolledUp = useRef(false)
-  const touchStartY = useRef(0)
+  const isAtBottomRef = useRef(true)
 
   const updateStickiness = useCallback(() => {
     const state = listRef.current?.getState?.()
     if (!state) return
-    if (userScrolledUp.current) {
-      if (state.isAtEnd) userScrolledUp.current = false
-      return
-    }
+    isAtBottomRef.current = state.isAtEnd
     setIsAtBottom((current) =>
       current === state.isAtEnd ? current : state.isAtEnd,
     )
@@ -83,15 +73,17 @@ export function Conversation<TItem>({
 
   const scrollToBottom = useCallback(() => {
     listRef.current?.scrollToEnd?.({ animated: true })
-    userScrolledUp.current = false
+    isAtBottomRef.current = true
     setIsAtBottom(true)
   }, [])
 
-  const scrollToBottomOnLoad = useCallback(() => {
-    if (data.length === 0) return
-    listRef.current?.scrollToEnd?.({ animated: false })
-    setIsAtBottom((current) => (current ? current : true))
-  }, [data.length])
+  useEffect(() => {
+    if (!isAtBottomRef.current) return
+    const id = requestAnimationFrame(() => {
+      listRef.current?.scrollToEnd?.({ animated: false })
+    })
+    return () => cancelAnimationFrame(id)
+  }, [data])
 
   const rawRows = useMemo(
     () =>
@@ -117,36 +109,6 @@ export function Conversation<TItem>({
     [renderDataItem],
   )
 
-  const handleWheel = useCallback(
-    (event: ReactWheelEvent<HTMLDivElement>) => {
-      if (event.deltaY < 0) {
-        userScrolledUp.current = true
-        setIsAtBottom(false)
-      }
-      onWheel?.(event)
-    },
-    [onWheel],
-  )
-
-  const handleTouchStart = useCallback(
-    (event: ReactTouchEvent<HTMLDivElement>) => {
-      touchStartY.current = event.touches[0]!.clientY
-      onTouchStart?.(event)
-    },
-    [onTouchStart],
-  )
-
-  const handleTouchMove = useCallback(
-    (event: ReactTouchEvent<HTMLDivElement>) => {
-      const dy = event.touches[0]!.clientY - touchStartY.current
-      if (dy > 10) {
-        userScrolledUp.current = true
-        setIsAtBottom(false)
-      }
-    },
-    [],
-  )
-
   const contextValue = useMemo(
     () => ({ isAtBottom, scrollToBottom }),
     [isAtBottom, scrollToBottom],
@@ -157,9 +119,6 @@ export function Conversation<TItem>({
       <div
         role="log"
         {...props}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onWheel={handleWheel}
         className={cn('relative min-h-0 flex-1 overflow-hidden', className)}
       >
         <LegendList<ConversationRow<TItem>>
@@ -172,9 +131,8 @@ export function Conversation<TItem>({
           estimatedListSize={estimatedListSize}
           estimatedItemSize={estimateItemSize}
           initialContainerPoolRatio={initialContainerPoolRatio}
-          maintainScrollAtEnd={isAtBottom}
+          maintainScrollAtEnd={false}
           maintainScrollAtEndThreshold={0.1}
-          onLoad={scrollToBottomOnLoad}
           onScroll={updateStickiness}
           className="h-full overflow-x-hidden overscroll-y-contain"
         />

--- a/apps/web/src/components/ai-elements/conversation.tsx
+++ b/apps/web/src/components/ai-elements/conversation.tsx
@@ -148,7 +148,7 @@ export function Conversation<TItem>({
           estimatedListSize={estimatedListSize}
           estimatedItemSize={estimateItemSize}
           initialContainerPoolRatio={initialContainerPoolRatio}
-          maintainScrollAtEnd
+          maintainScrollAtEnd={isAtBottom}
           maintainScrollAtEndThreshold={0.1}
           onLoad={scrollToBottomOnLoad}
           onScroll={updateStickiness}


### PR DESCRIPTION
## Bug: Can't scroll up when Garden agent is thinking

**ss:**

https://github.com/user-attachments/assets/1f1037c5-c731-413c-aea4-5825fc0f5c0c

**Root cause:** `LegendList` in the Conversation component had `maintainScrollAtEnd` hardcoded to `true`. This forced scroll-to-bottom on every data update (including the thinking indicator appearing/disappearing), preventing users from scrolling up to read previous messages.

**Fix:** Bound `maintainScrollAtEnd` to the `isAtBottom` state from `updateStickiness`. Now the list only auto-scrolls to end when the user is already at the bottom. Scrolling up sets `isAtBottom = false`, disabling the auto-scroll behavior.

**File:** `apps/web/src/components/ai-elements/conversation.tsx`

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation scrolling so the view stays anchored at the end only when already at the bottom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation scrolling so new content keeps the view at the bottom when it is already there.
  * Preserved the reading position when viewing earlier conversation content, including after upward wheel or touch gestures.
  * Restored automatic bottom scrolling after returning to the end of the conversation.
  * Prevented unnecessary scrolling while users are actively reading older messages.

* **Tests**
  * Added coverage for scrolling behavior during content updates and user navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->