### PR TITLE
chore: change local Postgres host port to 15432

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ AI_GATEWAY_ID=
 BETTER_AUTH_URL=http://localhost:3000
 # Local Docker Postgres from `pnpm offline:up` — the recommended database
 # for all local dev. Swap for your own (e.g. Neon) if you need one.
-DATABASE_URL=postgresql://garden:garden@localhost:55432/garden
+DATABASE_URL=postgresql://garden:garden@localhost:15432/garden
 BETTER_AUTH_SECRET=
 EXECUTOR_SECRET_KEY=
 RESEND_API_KEY=
@@ -45,7 +45,7 @@ DISCORD_BOT_PERMISSIONS=
 # defaults automatically. Uncomment only to override. Local Postgres + Ollama
 # come from `pnpm offline:up` / `pnpm offline:up:ollama` (compose.dev.yaml).
 # GARDEN_OFFLINE=1
-# DATABASE_URL=postgresql://garden:garden@localhost:55432/garden
+# DATABASE_URL=postgresql://garden:garden@localhost:15432/garden
 # GARDEN_MODEL_PROVIDER=openai-compatible
 # GARDEN_MODEL_BASE_URL=http://localhost:11434/v1
 # GARDEN_MODEL_ID=qwen3:8b

--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ Workers free plan (see above).
 `pnpm --filter @garden/db db:migrate`. For a non-Docker database, check the
 connection string and that the user can create and alter tables.
 
-**Postgres port conflict:** the local Postgres maps port 55432 specifically
-to avoid a system Postgres on 5432; if 55432 is also taken, override
+**Postgres port conflict:** the local Postgres maps port 15432 specifically
+to avoid a system Postgres on 5432; if 15432 is also taken, override
 `DATABASE_URL`.
 
 **A connector is unavailable:** provider credentials are optional. Add only

--- a/apps/web/scripts/dev.mjs
+++ b/apps/web/scripts/dev.mjs
@@ -38,7 +38,7 @@ if (offline) {
     delete process.env.DATABASE_URL
   }
   process.env.DATABASE_URL ??=
-    'postgresql://garden:garden@localhost:55432/garden'
+    'postgresql://garden:garden@localhost:15432/garden'
 }
 if (!args.has('--containers')) {
   process.env.ENVIRONMENT = 'development'

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -2,7 +2,7 @@
 #
 # `pnpm offline:up` boots Postgres for local dev (the recommended database for
 # ALL local development — a fresh, private DB that `pnpm --filter @garden/db
-# db:migrate` can own; Neon is for staging/deploys). Port 55432 avoids
+# db:migrate` can own; Neon is for staging/deploys). Port 15432 avoids
 # colliding with any system Postgres on 5432.
 #
 # `pnpm offline:up:ollama` additionally starts Ollama for offline mode
@@ -12,7 +12,7 @@ services:
   postgres:
     image: postgres:16-alpine
     ports:
-      - '55432:5432'
+      - '15432:5432'
     environment:
       POSTGRES_USER: garden
       POSTGRES_PASSWORD: garden


### PR DESCRIPTION
# Summary

Change the local development Postgres host port from 55432 to 15432.

The previous port was in the dynamic/private port range. This change uses a
dedicated alternate development port while keeping the container-side Postgres
port unchanged at 5432.

## Scope

- In scope:
  - Update local development Postgres port references in Compose, `.env.example`,
    README instructions, and the dev script fallback.
- Out of scope:
  - Changing the Postgres container configuration or database behavior.
  - Changing production/staging database configuration.

## Invariants

- [x] The container-side Postgres port remains 5432.
- [x] Local development continues to use the same database credentials and URL
      format.
- [x] Existing users can override `DATABASE_URL` if the host port conflicts.