### PR TITLE
fix(ui): make tooltip labels readable

### DIFF
--- a/packages/ui/components/ui/kbd.tsx
+++ b/packages/ui/components/ui/kbd.tsx
@@ -5,7 +5,7 @@ function Kbd({ className, ...props }: React.ComponentProps<'kbd'>) {
     <kbd
       data-slot="kbd"
       className={cn(
-        "pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none in-data-[slot=tooltip-content]:bg-background/20 in-data-[slot=tooltip-content]:text-background dark:in-data-[slot=tooltip-content]:bg-background/10 [&_svg:not([class*='size-'])]:size-3",
+        "pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none [&_svg:not([class*='size-'])]:size-3",
         className,
       )}
       {...props}

--- a/packages/ui/components/ui/tooltip.tsx
+++ b/packages/ui/components/ui/tooltip.tsx
@@ -50,13 +50,13 @@ function TooltipContent({
         <TooltipPrimitive.Popup
           data-slot="tooltip-content"
           className={cn(
-            'z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+            'z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-[var(--shadow-float-1)] ring-1 ring-foreground/10 has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
             className,
           )}
           {...props}
         >
           {children}
-          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-popover fill-popover data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>


### PR DESCRIPTION
# Summary

Sidebar (and every other) tooltip rendered as a near-black chip with unreadable text. Garden maps `--background` to `transparent` so parchment shows through the page; the shadcn inverted pair `bg-foreground text-background` therefore painted ink fill with invisible (`transparent`) text.

Tooltips now use the opaque popover surface (`bg-popover` / `text-popover-foreground`) already used by HoverCard and Popover — ink on vellum, with the matching arrow. Keyboard hint styles that assumed an inverted tooltip were dropped so they don't go invisible on the light surface.

Impact: rail labels, settings, issue actions, and any other `TooltipContent` are readable. No product behavior change.

## Scope

- In scope:
  - `packages/ui/components/ui/tooltip.tsx` surface + arrow tokens
  - `packages/ui/components/ui/kbd.tsx` tooltip-inverted kbd overrides
- Out of scope:
  - `--background` remaining transparent (intentional for page atmosphere)
  - other `bg-foreground text-background` call sites (onboarding CTAs, automation chips)
  - tooltip delay, placement, or content

## Invariants

List the business and engineering rules that must remain true.

- [x] Canonical identity is defined where records/events are involved. N/A — presentation only.
- [x] Re-running the operation does not duplicate effects. N/A — no writes.
- [x] Partial failure cannot silently corrupt state. N/A — no persistence.
- [x] Public outputs do not expose private or internal data. Tooltip copy is unchanged; only colors/shadow.

## Design

Source of truth for floating chrome is `--popover` / `--popover-foreground` (`vellum-heavy` + `ink`). `--background` stays transparent by design; it is not a text color. Read path is CSS only. No error/retry surface. Simplest safe fix is reuse the existing opaque popover tokens instead of introducing new ones or making `--background` opaque (which would flatten the parchment ground).

## Duplicate and idempotency review

- Stable idempotency/dedupe key: N/A
- Persisted-data duplicate check: N/A
- Same-batch duplicate check: N/A
- Retry behavior: N/A
- Conflict behavior: N/A

## Privacy and security review

- Data classification: none — UI chrome
- Public fields explicitly allowlisted: N/A
- Private links/identifiers suppressed: N/A
- Secrets and permissions reviewed: no auth, API, or grant changes

## Data, migration, and rollback

- Schema/data changes: none
- Backup completed or not applicable: N/A
- Dry-run/preview result: N/A
- Expected affected-record count: 0
- Rollback procedure: revert the commit

## Verification

- [ ] Syntax/build/compile — not run for this CSS-only change
- [ ] Formatting/lint — not run
- [ ] Type checks — not run
- [ ] Unit tests — none added; no tooltip unit coverage existed
- [ ] Integration tests — N/A
- [ ] Repeat-run/idempotency test — N/A
- [ ] Malformed-input test — N/A
- [ ] Partial-failure test — N/A
- [ ] Privacy-output test — N/A
- [x] Before/after reconciliation — computed styles on the running local app

Commands and actual results:

```text
Runtime.evaluate getComputedStyle on live localhost:3000

css vars:
  --background: transparent
  --foreground: #1a1f1c
  --popover: rgba(255, 255, 255, 0.96)
  --popover-foreground: #1a1f1c

old pair (bg-foreground text-background):
  backgroundColor: rgb(26, 31, 28)
  color: rgba(0, 0, 0, 0)          # invisible text

new pair (bg-popover text-popover-foreground):
  backgroundColor: rgba(255, 255, 255, 0.96)
  color: rgb(26, 31, 28)           # ink on vellum
```

Manual: hover a collapsed-rail icon (e.g. Connections) and confirm the label is ink on a light chip, not a black empty blob. Could not hover the authenticated sidebar from the agent browser (redirected to login); token measurement used the same live stylesheet.

## Operations

- Configuration changes: none
- Deployment/restart steps: normal web deploy; no extra restart
- Health checks: none added
- Monitoring/alerts: none
- Post-deploy verification: hover any rail icon in a collapsed sidebar

## Agent declaration

- [x] I read the applicable `AGENTS.md` instructions.
- [x] I did not perform unapproved destructive production actions.
- [x] I have clearly stated any checks I could not run.
- [x] The patch does not include unrelated refactoring.


### Media
<img width="1220" height="702" alt="Screenshot 2026-08-29 at 11 05 55 AM" src="https://github.com/user-attachments/assets/82e9d079-bea4-45db-9641-1491dcabe95e" />
<img width="1220" height="702" alt="Screenshot 2026-08-29 at 11 25 51 AM" src="https://github.com/user-attachments/assets/102d2b69-00dd-4ed0-8e8e-8ced78aec330" />


