### PR TITLE
fix(auth): unblock workspace invitation acceptance

### DIFF
--- a/apps/web/src/components/login-form.tsx
+++ b/apps/web/src/components/login-form.tsx
@@ -34,11 +34,13 @@ export function LoginForm({
   name,
   email,
   emailReadonly,
+  modeLocked = false,
   invitationStatusMessage,
   invitationWorkspaceName,
   password,
   error,
   loading,
+  redirectTarget,
   onSubmit,
   onNameChange,
   onEmailChange,
@@ -49,11 +51,18 @@ export function LoginForm({
   name: string
   email: string
   emailReadonly?: boolean
+  /**
+   * Hides the sign-in/sign-up toggle. Invitation flows pick the correct mode
+   * server-side (existing users sign in, new users sign up); letting the user
+   * flip manually strands them in the wrong auth mode with a locked email.
+   */
+  modeLocked?: boolean
   invitationStatusMessage?: string
   invitationWorkspaceName?: string
   password: string
   error?: string
   loading?: boolean
+  redirectTarget?: string
   onSubmit: (event: React.FormEvent<HTMLFormElement>) => void
   onNameChange: (value: string) => void
   onEmailChange: (value: string) => void
@@ -68,6 +77,16 @@ export function LoginForm({
       ? `Use this invite email to join ${invitationWorkspaceName}.`
       : `Use the invited account to join ${invitationWorkspaceName}.`
     : undefined
+  // Keeps the invitation redirect alive through the recovery detour so a reset
+  // returns the user to the invite instead of a bare workspace.
+  const forgotPasswordHref = (() => {
+    const params = new URLSearchParams()
+    const trimmedEmail = email.trim()
+    if (trimmedEmail) params.set('email', trimmedEmail)
+    if (redirectTarget) params.set('redirect', redirectTarget)
+    const query = params.toString()
+    return query ? `/forgot-password?${query}` : '/forgot-password'
+  })()
 
   return (
     <div className={cn('flex flex-col', className)}>
@@ -138,11 +157,7 @@ export function LoginForm({
                 <FieldLabel htmlFor="password">Password</FieldLabel>
                 {!isSignup ? (
                   <a
-                    href={
-                      email.trim()
-                        ? `/forgot-password?email=${encodeURIComponent(email.trim())}`
-                        : '/forgot-password'
-                    }
+                    href={forgotPasswordHref}
                     className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground hover:underline hover:underline-offset-4"
                   >
                     Forgot password?
@@ -195,16 +210,18 @@ export function LoginForm({
               </Button>
             </Field>
 
-            <FieldDescription className="text-center">
-              {isSignup ? 'Already have an account?' : 'New here?'}{' '}
-              <button
-                type="button"
-                onClick={onToggleMode}
-                className="font-medium text-foreground underline underline-offset-4"
-              >
-                {isSignup ? 'Sign in' : 'Create an account'}
-              </button>
-            </FieldDescription>
+            {modeLocked ? null : (
+              <FieldDescription className="text-center">
+                {isSignup ? 'Already have an account?' : 'New here?'}{' '}
+                <button
+                  type="button"
+                  onClick={onToggleMode}
+                  className="font-medium text-foreground underline underline-offset-4"
+                >
+                  {isSignup ? 'Sign in' : 'Create an account'}
+                </button>
+              </FieldDescription>
+            )}
             {isSignup ? (
               <FieldDescription className="text-center text-[11px] leading-4">
                 By creating an account, you agree to our{' '}

--- a/apps/web/src/features/auth/login-page.test.tsx
+++ b/apps/web/src/features/auth/login-page.test.tsx
@@ -138,6 +138,37 @@ describe('LoginPage', () => {
     )
   })
 
+  it('preserves the invitation redirect in the forgot-password link', () => {
+    renderLoginPage({
+      initialEmail: 'invitee@example.com',
+      lockedEmail: true,
+      redirectTarget: '/invitations/9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d',
+    })
+
+    expect(
+      screen.getByRole('link', { name: /forgot password/i }),
+    ).toHaveAttribute(
+      'href',
+      '/forgot-password?email=invitee%40example.com&redirect=%2Finvitations%2F9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d',
+    )
+  })
+
+  it.each([
+    ['signin', /create an account/i],
+    ['signup', /^sign in$/i],
+  ] as const)('locks %s mode during a pending invite flow', (mode, toggleName) => {
+    renderLoginPage({
+      initialEmail: 'invitee@example.com',
+      initialMode: mode,
+      lockedEmail: true,
+      invitationWorkspaceName: 'Garden Dev',
+    })
+
+    expect(
+      screen.queryByRole('button', { name: toggleName }),
+    ).not.toBeInTheDocument()
+  })
+
   it('keeps privacy and terms available from the public auth surface', () => {
     renderLoginPage()
 

--- a/apps/web/src/features/auth/login-page.tsx
+++ b/apps/web/src/features/auth/login-page.tsx
@@ -21,6 +21,7 @@ export function LoginPage({
   invitationStatusMessage,
   invitationWorkspaceName,
   lockedEmail = false,
+  redirectTarget,
 }: {
   onSuccess: () => void
   initialEmail?: string
@@ -28,6 +29,11 @@ export function LoginPage({
   invitationStatusMessage?: string
   invitationWorkspaceName?: string
   lockedEmail?: boolean
+  /**
+   * Sanitized post-auth target (usually an invite link). Threaded into the
+   * forgot-password link so the recovery detour returns to the same flow.
+   */
+  redirectTarget?: string
 }) {
   const [mode, setMode] = useState<'signin' | 'signup'>(initialMode)
   const [name, setName] = useState('')
@@ -99,8 +105,10 @@ export function LoginPage({
           onSubmit={handleSubmit}
           onNameChange={setName}
           emailReadonly={lockedEmail}
+          modeLocked={lockedEmail}
           invitationStatusMessage={invitationStatusMessage}
           invitationWorkspaceName={invitationWorkspaceName}
+          redirectTarget={redirectTarget}
           onEmailChange={lockedEmail ? () => undefined : setEmail}
           onPasswordChange={setPassword}
           onToggleMode={() =>

--- a/apps/web/src/features/auth/password-recovery-page.test.tsx
+++ b/apps/web/src/features/auth/password-recovery-page.test.tsx
@@ -93,4 +93,47 @@ describe('password recovery', () => {
       })
     })
   })
+
+  it('threads the invitation redirect through the whole recovery detour', async () => {
+    const user = userEvent.setup()
+    const inviteRedirect = '/invitations/9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d'
+    const { unmount } = render(
+      <RequestPasswordResetPage
+        initialEmail="ada@example.com"
+        redirectTarget={inviteRedirect}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /send reset link/i }))
+
+    await waitFor(() => {
+      expect(mockRequestPasswordReset).toHaveBeenCalledWith({
+        email: 'ada@example.com',
+        redirectTo: `http://localhost:3000/reset-password?redirect=${encodeURIComponent(inviteRedirect)}`,
+      })
+    })
+    unmount()
+
+    render(
+      <ResetPasswordPage
+        token="valid-token"
+        invalidToken={false}
+        redirectTarget={inviteRedirect}
+      />,
+    )
+    await user.type(screen.getByLabelText(/^new password$/i), 'password-new')
+    await user.type(
+      screen.getByLabelText(/confirm new password/i),
+      'password-new',
+    )
+    await user.click(screen.getByRole('button', { name: /update password/i }))
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: '/login',
+        search: { redirect: inviteRedirect },
+        replace: true,
+      })
+    })
+  })
 })

--- a/apps/web/src/features/auth/password-recovery-page.tsx
+++ b/apps/web/src/features/auth/password-recovery-page.tsx
@@ -54,8 +54,14 @@ async function runRecoveryRequest(request: Promise<AuthResponse>) {
 
 export function RequestPasswordResetPage({
   initialEmail = '',
+  redirectTarget,
 }: {
   initialEmail?: string
+  /**
+   * Sanitized post-auth target (usually an invite link). Appended to the
+   * emailed reset URL so completing recovery returns to the original flow.
+   */
+  redirectTarget?: string
 }) {
   const [email, setEmail] = useState(initialEmail)
   const [error, setError] = useState('')
@@ -68,10 +74,16 @@ export function RequestPasswordResetPage({
     setLoading(true)
     setError('')
 
+    const resetUrl = new URL(
+      '/reset-password',
+      window.location.origin,
+    )
+    if (redirectTarget) resetUrl.searchParams.set('redirect', redirectTarget)
+
     void runRecoveryRequest(
       authClient.requestPasswordReset({
         email,
-        redirectTo: `${window.location.origin}/reset-password`,
+        redirectTo: resetUrl.href,
       }),
     )
       .then((result) =>
@@ -108,7 +120,7 @@ export function RequestPasswordResetPage({
           >
             Send another link
           </Button>
-          <BackToSignIn />
+          <BackToSignIn redirectTarget={redirectTarget} />
         </div>
       ) : (
         <form onSubmit={handleSubmit}>
@@ -138,7 +150,7 @@ export function RequestPasswordResetPage({
                 {loading ? 'Sending link...' : 'Send reset link'}
               </Button>
             </Field>
-            <BackToSignIn />
+            <BackToSignIn redirectTarget={redirectTarget} />
           </FieldGroup>
         </form>
       )}
@@ -149,9 +161,12 @@ export function RequestPasswordResetPage({
 export function ResetPasswordPage({
   token,
   invalidToken,
+  redirectTarget,
 }: {
   token?: string
   invalidToken: boolean
+  /** Sanitized post-auth target preserved from the emailed reset URL. */
+  redirectTarget?: string
 }) {
   const navigate = useNavigate()
   const [password, setPassword] = useState('')
@@ -180,7 +195,7 @@ export function ResetPasswordPage({
             toast.success('Password updated. Sign in with your new password.')
             void navigate({
               to: '/login',
-              search: { redirect: undefined },
+              search: { redirect: redirectTarget },
               replace: true,
             })
           },
@@ -206,13 +221,13 @@ export function ResetPasswordPage({
         <div className="space-y-4">
           <Link
             to="/forgot-password"
-            search={{ email: undefined }}
+            search={{ email: undefined, redirect: redirectTarget }}
             className={buttonVariants({ className: 'w-full' })}
           >
             Request a new link
             <ArrowRightIcon className="size-4" />
           </Link>
-          <BackToSignIn />
+          <BackToSignIn redirectTarget={redirectTarget} />
         </div>
       ) : (
         <form onSubmit={handleSubmit}>
@@ -298,12 +313,12 @@ function RecoveryShell({
   )
 }
 
-function BackToSignIn() {
+function BackToSignIn({ redirectTarget }: { redirectTarget?: string }) {
   return (
     <FieldDescription className="text-center">
       <Link
         to="/login"
-        search={{ redirect: undefined }}
+        search={{ redirect: redirectTarget }}
         className="inline-flex items-center gap-1 font-medium text-foreground underline underline-offset-4"
       >
         <ArrowLeftIcon className="size-3.5" />

--- a/apps/web/src/features/settings/components/members-tab.tsx
+++ b/apps/web/src/features/settings/components/members-tab.tsx
@@ -10,7 +10,7 @@ import {
   X,
   Mail,
   MailWarning,
-  SendHorizonal,
+  SendHorizontal,
 } from 'lucide-react'
 import { ActorAvatar } from '../../common/actor-avatar'
 import type { MemberWithUser, MemberRole, Invitation } from '@garden/core/types'
@@ -224,7 +224,7 @@ function InvitationRow({
             onClick={onResend}
             title={expired ? 'Resend (extends expiry)' : 'Resend invitation'}
           >
-            <SendHorizonal className="h-4 w-4 text-muted-foreground" />
+            <SendHorizontal className="h-4 w-4 text-muted-foreground" />
           </Button>
           <Button
             variant="ghost"

--- a/apps/web/src/features/settings/components/members-tab.tsx
+++ b/apps/web/src/features/settings/components/members-tab.tsx
@@ -9,6 +9,8 @@ import {
   Clock,
   X,
   Mail,
+  MailWarning,
+  SendHorizonal,
 } from 'lucide-react'
 import { ActorAvatar } from '../../common/actor-avatar'
 import type { MemberWithUser, MemberRole, Invitation } from '@garden/core/types'
@@ -175,41 +177,65 @@ function MemberRow({
   )
 }
 
+/**
+ * Invitation rows distinguish expired invites (pending status, past
+ * expiresAt) from live ones so admins see why a link stopped working, and get
+ * a one-click resend that refreshes the same invite instead of creating a
+ * duplicate row.
+ */
 function InvitationRow({
   invitation,
   canManage,
   onRevoke,
+  onResend,
   busy,
 }: {
   invitation: Invitation
   canManage: boolean
   onRevoke: () => void
+  onResend: () => void
   busy: boolean
 }) {
   const rc = roleConfig[invitation.role]
+  const expired = new Date(invitation.expiresAt).getTime() <= Date.now()
 
   return (
     <li className="flex items-center gap-3 py-3">
       <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted">
-        <Mail className="h-4 w-4 text-muted-foreground" />
+        {expired ? (
+          <MailWarning className="h-4 w-4 text-muted-foreground" />
+        ) : (
+          <Mail className="h-4 w-4 text-muted-foreground" />
+        )}
       </div>
       <div className="min-w-0 flex-1">
         <div className="truncate text-sm font-medium">{invitation.email}</div>
         <div className="flex items-center gap-1 text-xs text-muted-foreground">
           <Clock className="h-3 w-3" />
-          <span>Pending</span>
+          <span>{expired ? 'Expired — resend to reactivate' : 'Pending'}</span>
         </div>
       </div>
       {canManage && (
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          disabled={busy}
-          onClick={onRevoke}
-          title="Revoke invitation"
-        >
-          <X className="h-4 w-4 text-muted-foreground" />
-        </Button>
+        <>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            disabled={busy}
+            onClick={onResend}
+            title={expired ? 'Resend (extends expiry)' : 'Resend invitation'}
+          >
+            <SendHorizonal className="h-4 w-4 text-muted-foreground" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            disabled={busy}
+            onClick={onRevoke}
+            title="Revoke invitation"
+          >
+            <X className="h-4 w-4 text-muted-foreground" />
+          </Button>
+        </>
       )}
       <Badge variant="outline">{rc.label}</Badge>
     </li>
@@ -286,6 +312,27 @@ export function MembersTab() {
         }
       },
     })
+  }
+
+  const handleResendInvitation = (invitation: Invitation) => {
+    if (!workspace) return
+    setInvitationActionId(invitation.id)
+    void api
+      .createMember(workspace.id, {
+        email: invitation.email,
+        role: invitation.role,
+        resend: true,
+      })
+      .then(() => {
+        qc.invalidateQueries({ queryKey: workspaceKeys.invitations(wsId) })
+        toast.success(`Invitation resent to ${invitation.email}`)
+      })
+      .catch((e: unknown) => {
+        toast.error(
+          e instanceof Error ? e.message : 'Failed to resend invitation',
+        )
+      })
+      .finally(() => setInvitationActionId(null))
   }
 
   const handleRoleChange = async (memberId: string, role: MemberRole) => {
@@ -412,6 +459,7 @@ export function MembersTab() {
                 invitation={inv}
                 canManage={canManageWorkspace}
                 onRevoke={() => handleRevokeInvitation(inv)}
+                onResend={() => handleResendInvitation(inv)}
                 busy={invitationActionId === inv.id}
               />
             ))}

--- a/apps/web/src/lib/auth/instance.ts
+++ b/apps/web/src/lib/auth/instance.ts
@@ -1,20 +1,20 @@
-import { Effect, Result as EffectResult } from 'effect'
-import { betterAuth } from 'better-auth'
-import { createAuthMiddleware, getOAuthState } from 'better-auth/api'
-import { Result, matchError } from 'better-result'
-import { drizzleAdapter } from 'better-auth/adapters/drizzle'
-import { and, eq } from 'drizzle-orm'
-import { createAccessControl } from 'better-auth/plugins/access'
-import { defaultStatements } from 'better-auth/plugins/organization/access'
-import { organization } from 'better-auth/plugins'
-import { genericOAuth } from 'better-auth/plugins/generic-oauth'
-import { connectorRegistry } from '@garden/connectors'
-import { GARDEN_ANALYTICS_EVENTS } from '@garden/observability/analytics/events'
-import { buildConnectorOAuthConfigs } from '@garden/connectors/oauth'
+import { Effect, Result as EffectResult } from "effect";
+import { betterAuth } from "better-auth";
+import { createAuthMiddleware, getOAuthState } from "better-auth/api";
+import { Result, matchError } from "better-result";
+import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { and, eq } from "drizzle-orm";
+import { createAccessControl } from "better-auth/plugins/access";
+import { defaultStatements } from "better-auth/plugins/organization/access";
+import { organization } from "better-auth/plugins";
+import { genericOAuth } from "better-auth/plugins/generic-oauth";
+import { connectorRegistry } from "@garden/connectors";
+import { GARDEN_ANALYTICS_EVENTS } from "@garden/observability/analytics/events";
+import { buildConnectorOAuthConfigs } from "@garden/connectors/oauth";
 import {
   createGardenLogger,
   type GardenLogLevel,
-} from '@garden/observability/logger'
+} from "@garden/observability/logger";
 import {
   account,
   invitation,
@@ -23,66 +23,66 @@ import {
   session,
   user,
   verification,
-} from '@garden/db/schema'
+} from "@garden/db/schema";
 import {
   syncCapabilities,
   type CapabilitySyncError,
-} from '@/lib/server/capability-sync'
+} from "@/lib/server/capability-sync";
 import {
   ConnectorCallbackDatabaseError,
   recordConnectorCallbackEvent,
   type ConnectorCallbackStatus,
-} from '@/lib/server/connector-callback-events'
-import type { AppEnv } from '@/lib/server/env'
+} from "@/lib/server/connector-callback-events";
+import type { AppEnv } from "@/lib/server/env";
 import {
   capturePostHogEventWithScheduler,
   capturePostHogHandledErrorWithScheduler,
-} from '@/lib/posthog-server'
-import type { Db } from '@/lib/server/db'
-import { sendPasswordResetEmail } from '@/lib/server/email/password-reset'
+} from "@/lib/posthog-server";
+import type { Db } from "@/lib/server/db";
+import { sendPasswordResetEmail } from "@/lib/server/email/password-reset";
 
 export type GardenAuthEnv = Pick<
   AppEnv,
-  | 'BETTER_AUTH_SECRET'
-  | 'BETTER_AUTH_URL'
-  | 'GITHUB_CLIENT_ID'
-  | 'GITHUB_CLIENT_SECRET'
-  | 'GOOGLE_CLIENT_ID'
-  | 'GOOGLE_CLIENT_SECRET'
-  | 'SLACK_CLIENT_ID'
-  | 'SLACK_CLIENT_SECRET'
-  | 'RESEND_API_KEY'
-  | 'ENVIRONMENT'
-  | 'VITE_PUBLIC_POSTHOG_HOST'
-  | 'VITE_PUBLIC_POSTHOG_PROJECT_TOKEN'
->
+  | "BETTER_AUTH_SECRET"
+  | "BETTER_AUTH_URL"
+  | "GITHUB_CLIENT_ID"
+  | "GITHUB_CLIENT_SECRET"
+  | "GOOGLE_CLIENT_ID"
+  | "GOOGLE_CLIENT_SECRET"
+  | "SLACK_CLIENT_ID"
+  | "SLACK_CLIENT_SECRET"
+  | "RESEND_API_KEY"
+  | "ENVIRONMENT"
+  | "VITE_PUBLIC_POSTHOG_HOST"
+  | "VITE_PUBLIC_POSTHOG_PROJECT_TOKEN"
+>;
 
 type GardenAuthRuntime = GardenAuthEnv & {
-  request?: Request
-  waitUntil?: (promise: Promise<unknown>) => void
-}
+  request?: Request;
+  waitUntil?: (promise: Promise<unknown>) => void;
+};
 
-type AuthDatabase = Db
-type AccountRecord = typeof account.$inferInsert
+type AuthDatabase = Db;
+type AccountRecord = typeof account.$inferInsert;
 type HookSession = {
   session: {
-    activeOrganizationId?: string | null
-  }
+    activeOrganizationId?: string | null;
+  };
   user: {
-    id: string
-  }
-}
+    id: string;
+  };
+};
 type HookContext = {
-  params?: Record<string, unknown>
-  path?: string
+  params?: Record<string, unknown>;
+  path?: string;
   context: {
     logger: {
-      error: (...args: unknown[]) => void
-    }
-    newSession: HookSession | null
-    session: HookSession | null
-  }
-} | null
+      error: (...args: unknown[]) => void;
+    };
+    newSession: HookSession | null;
+    session: HookSession | null;
+  };
+} | null;
 
 const authSchema = {
   user,
@@ -92,12 +92,12 @@ const authSchema = {
   organization: organizationTable,
   member: memberTable,
   invitation,
-}
+};
 
 const betterAuthLogger = createGardenLogger({
-  service: 'garden-staging',
-  component: 'better-auth',
-})
+  service: "garden-staging",
+  component: "better-auth",
+});
 
 /**
  * Replaces Better Auth's default console logger with Garden's redacting error
@@ -108,115 +108,115 @@ const betterAuthLogger = createGardenLogger({
  * logger option source and local Cloudflare Workers structured logging helper.
  */
 function logBetterAuthError(
-  level: Exclude<GardenLogLevel, 'success'>,
+  level: Exclude<GardenLogLevel, "success">,
   message: string,
   ...args: unknown[]
 ) {
-  if (level !== 'error') return
-  betterAuthLogger.error('better_auth.error', {
+  if (level !== "error") return;
+  betterAuthLogger.error("better_auth.error", {
     betterAuthMessage: message,
     ...(args.length > 0 ? { betterAuthArgs: args } : {}),
-  })
+  });
 }
 
 const gardenAccessControl = createAccessControl({
   ...defaultStatements,
-  agent: ['create', 'update', 'delete'],
-  connection: ['update'],
-  issue: ['update'],
-  permission: ['approve', 'grant'],
-  skill: ['create', 'update', 'delete'],
-})
+  agent: ["create", "update", "delete"],
+  connection: ["update"],
+  issue: ["update"],
+  permission: ["approve", "grant"],
+  skill: ["create", "update", "delete"],
+});
 
 const gardenOwnerRole = gardenAccessControl.newRole({
   ...defaultStatements,
-  agent: ['create', 'update', 'delete'],
-  connection: ['update'],
-  issue: ['update'],
-  permission: ['approve', 'grant'],
-  skill: ['create', 'update', 'delete'],
-})
+  agent: ["create", "update", "delete"],
+  connection: ["update"],
+  issue: ["update"],
+  permission: ["approve", "grant"],
+  skill: ["create", "update", "delete"],
+});
 
 const gardenAdminRole = gardenAccessControl.newRole({
-  organization: ['update'],
-  member: ['create', 'update', 'delete'],
-  invitation: ['create', 'cancel'],
-  team: ['create', 'update', 'delete'],
-  ac: ['create', 'read', 'update', 'delete'],
-  agent: ['create', 'update', 'delete'],
-  connection: ['update'],
-  issue: ['update'],
-  permission: ['approve', 'grant'],
-  skill: ['create', 'update', 'delete'],
-})
+  organization: ["update"],
+  member: ["create", "update", "delete"],
+  invitation: ["create", "cancel"],
+  team: ["create", "update", "delete"],
+  ac: ["create", "read", "update", "delete"],
+  agent: ["create", "update", "delete"],
+  connection: ["update"],
+  issue: ["update"],
+  permission: ["approve", "grant"],
+  skill: ["create", "update", "delete"],
+});
 
 const gardenMemberRole = gardenAccessControl.newRole({
   organization: [],
   member: [],
   invitation: [],
   team: [],
-  ac: ['read'],
+  ac: ["read"],
   agent: [],
   connection: [],
   issue: [],
   permission: [],
   skill: [],
-})
+});
 
 function getConnectorByProviderId(providerId: string | null | undefined) {
   return connectorRegistry.find(
     (connector) => connector.oauth?.providerId === providerId,
-  )
+  );
 }
 
 function readHookSession(context: HookContext) {
-  return context?.context.session ?? context?.context.newSession ?? null
+  return context?.context.session ?? context?.context.newSession ?? null;
 }
 
 function readProviderId(
   accountRecord: Partial<AccountRecord>,
   context: HookContext,
 ) {
-  const routeProviderId = context?.params?.providerId
-  if (typeof accountRecord.providerId === 'string') {
-    return accountRecord.providerId
+  const routeProviderId = context?.params?.providerId;
+  if (typeof accountRecord.providerId === "string") {
+    return accountRecord.providerId;
   }
 
-  return typeof routeProviderId === 'string' ? routeProviderId : undefined
+  return typeof routeProviderId === "string" ? routeProviderId : undefined;
 }
 
 function normalizeScopes(scope: string | null | undefined) {
   const scopes = scope
-    ?.split(',')
+    ?.split(",")
     .map((entry) => entry.trim())
-    .filter(Boolean)
+    .filter(Boolean);
 
-  return scopes && scopes.length > 0 ? scopes : undefined
+  return scopes && scopes.length > 0 ? scopes : undefined;
 }
 
 function decorateAccountRecord(
   accountRecord: Partial<AccountRecord>,
   context: HookContext,
 ) {
-  const providerId = readProviderId(accountRecord, context)
-  const connector = getConnectorByProviderId(providerId)
-  if (!connector) return undefined
+  const providerId = readProviderId(accountRecord, context);
+  const connector = getConnectorByProviderId(providerId);
+  if (!connector) return undefined;
 
-  const workspaceId = readHookSession(context)?.session.activeOrganizationId
-  const scopes = normalizeScopes(accountRecord.scope)
+  const workspaceId = readHookSession(context)?.session.activeOrganizationId;
+  const scopes = normalizeScopes(accountRecord.scope);
 
   return {
     ...accountRecord,
     connectorType: connector.id,
-    status: 'connected',
+    status: "connected",
     ...(workspaceId ? { workspaceId } : {}),
     ...(scopes ? { scopes } : {}),
-  }
+  };
 }
 
 function getRequestOrigin(request?: Request) {
-  if (!request || !URL.canParse(request.url)) return null
-  return new URL(request.url).origin
+  if (!request || !URL.canParse(request.url)) return null;
+  return new URL(request.url).origin;
 }
 
 function readOAuthCallbackFlow(
@@ -224,53 +224,53 @@ function readOAuthCallbackFlow(
   baseURL: string,
 ) {
   if (!callbackURL || !URL.canParse(callbackURL, baseURL)) {
-    return { flowId: undefined }
+    return { flowId: undefined };
   }
 
-  const url = new URL(callbackURL, baseURL)
-  const flowId = url.searchParams.get('connector_flow')?.trim() || undefined
-  return { flowId }
+  const url = new URL(callbackURL, baseURL);
+  const flowId = url.searchParams.get("connector_flow")?.trim() || undefined;
+  return { flowId };
 }
 
 type OAuthCallbackOutcome = {
-  status: ConnectorCallbackStatus
-  stage: string
-  message: string
-  errorCode?: string | null
-}
+  status: ConnectorCallbackStatus;
+  stage: string;
+  message: string;
+  errorCode?: string | null;
+};
 
 function syncResultToOAuthOutcome(args: {
-  connectorLabel: string
-  syncError?: CapabilitySyncError
+  connectorLabel: string;
+  syncError?: CapabilitySyncError;
 }): OAuthCallbackOutcome {
   if (args.syncError === undefined) {
     return {
-      status: 'success',
-      stage: 'connected',
+      status: "success",
+      stage: "connected",
       message: `${args.connectorLabel} connected.`,
-    }
+    };
   }
 
   return {
-    status: 'degraded',
+    status: "degraded",
     stage: args.syncError.code,
     message: `${args.connectorLabel} connected. Tool sync needs attention.`,
     errorCode: args.syncError.code,
-  }
+  };
 }
 
 async function markOAuthAccountDegraded(args: {
-  db: AuthDatabase
-  userId: string
-  workspaceId: string
-  providerId: string
+  db: AuthDatabase;
+  userId: string;
+  workspaceId: string;
+  providerId: string;
 }) {
   return Result.tryPromise({
     try: async () => {
       await args.db
         .update(account)
         .set({
-          status: 'degraded',
+          status: "degraded",
           updatedAt: new Date(),
         })
         .where(
@@ -279,18 +279,18 @@ async function markOAuthAccountDegraded(args: {
             eq(account.providerId, args.providerId),
             eq(account.workspaceId, args.workspaceId),
           ),
-        )
+        );
     },
     catch: (cause) =>
       new ConnectorCallbackDatabaseError({
-        operation: 'update',
+        operation: "update",
         cause,
         message:
           cause instanceof Error
             ? cause.message
-            : 'Failed to mark OAuth account as degraded',
+            : "Failed to mark OAuth account as degraded",
       }),
-  })
+  });
 }
 
 /**
@@ -302,28 +302,28 @@ async function markOAuthAccountDegraded(args: {
  * writes and avoids URL/tab state as product state.
  */
 async function finishOAuthConnectorCallback(args: {
-  db: AuthDatabase
-  userId: string
-  workspaceId: string
-  providerId: string
-  connectorId: NonNullable<ReturnType<typeof getConnectorByProviderId>>['id']
-  connectorLabel: string
-  flowId?: string | null
+  db: AuthDatabase;
+  userId: string;
+  workspaceId: string;
+  providerId: string;
+  connectorId: NonNullable<ReturnType<typeof getConnectorByProviderId>>["id"];
+  connectorLabel: string;
+  flowId?: string | null;
 }) {
   return Result.gen(async function* () {
     const syncResult = await Effect.runPromise(
       Effect.result(
         syncCapabilities(args.connectorId, args.userId, args.workspaceId),
       ),
-    )
+    );
     const outcome = syncResultToOAuthOutcome({
       connectorLabel: args.connectorLabel,
       syncError: EffectResult.isFailure(syncResult)
         ? syncResult.failure
         : undefined,
-    })
+    });
 
-    if (outcome.status === 'degraded') {
+    if (outcome.status === "degraded") {
       yield* Result.await(
         markOAuthAccountDegraded({
           db: args.db,
@@ -331,7 +331,7 @@ async function finishOAuthConnectorCallback(args: {
           workspaceId: args.workspaceId,
           providerId: args.providerId,
         }),
-      )
+      );
     }
 
     const event = yield* Result.await(
@@ -342,30 +342,30 @@ async function finishOAuthConnectorCallback(args: {
         connectorId: args.connectorId,
         providerId: args.providerId,
         flowId: args.flowId,
-        source: 'oauth',
+        source: "oauth",
         status: outcome.status,
         stage: outcome.stage,
         message: outcome.message,
         errorCode: outcome.errorCode,
       }),
-    )
+    );
 
-    return Result.ok({ outcome, event })
-  })
+    return Result.ok({ outcome, event });
+  });
 }
 
 export function createBetterAuth(db: AuthDatabase, env: GardenAuthRuntime) {
-  const runtimeOrigin = getRequestOrigin(env.request)
+  const runtimeOrigin = getRequestOrigin(env.request);
   const baseURL =
-    runtimeOrigin ?? env.BETTER_AUTH_URL ?? 'http://localhost:3000'
+    runtimeOrigin ?? env.BETTER_AUTH_URL ?? "http://localhost:3000";
   const trustedOrigins = Array.from(
     new Set([
-      'http://localhost:3000',
-      'http://localhost:3001',
+      "http://localhost:3000",
+      "http://localhost:3001",
       ...(env.BETTER_AUTH_URL ? [env.BETTER_AUTH_URL] : []),
       ...(runtimeOrigin ? [runtimeOrigin] : []),
     ]),
-  )
+  );
   const oauthEnv = {
     GITHUB_CLIENT_ID: env.GITHUB_CLIENT_ID,
     GITHUB_CLIENT_SECRET: env.GITHUB_CLIENT_SECRET,
@@ -373,24 +373,24 @@ export function createBetterAuth(db: AuthDatabase, env: GardenAuthRuntime) {
     GOOGLE_CLIENT_SECRET: env.GOOGLE_CLIENT_SECRET,
     SLACK_CLIENT_ID: env.SLACK_CLIENT_ID,
     SLACK_CLIENT_SECRET: env.SLACK_CLIENT_SECRET,
-  } satisfies Record<string, string | undefined>
+  } satisfies Record<string, string | undefined>;
 
   return betterAuth({
     secret: env.BETTER_AUTH_SECRET,
     baseURL,
     trustedOrigins,
     logger: {
-      level: 'error',
+      level: "error",
       log: logBetterAuthError,
     },
     database: drizzleAdapter(db, {
-      provider: 'pg',
+      provider: "pg",
       schema: authSchema,
     }),
     session: {
       cookieCache: {
         enabled: true,
-        strategy: 'compact',
+        strategy: "compact",
       },
     },
     databaseHooks: {
@@ -400,9 +400,9 @@ export function createBetterAuth(db: AuthDatabase, env: GardenAuthRuntime) {
             const decoratedAccount = decorateAccountRecord(
               accountRecord,
               context as HookContext,
-            )
+            );
 
-            return decoratedAccount ? { data: decoratedAccount } : undefined
+            return decoratedAccount ? { data: decoratedAccount } : undefined;
           },
         },
         update: {
@@ -410,9 +410,9 @@ export function createBetterAuth(db: AuthDatabase, env: GardenAuthRuntime) {
             const decoratedAccount = decorateAccountRecord(
               accountRecord,
               context as HookContext,
-            )
+            );
 
-            return decoratedAccount ? { data: decoratedAccount } : undefined
+            return decoratedAccount ? { data: decoratedAccount } : undefined;
           },
         },
       },
@@ -429,17 +429,17 @@ export function createBetterAuth(db: AuthDatabase, env: GardenAuthRuntime) {
             email: resetUser.email,
             name: resetUser.name,
           },
-        })
+        });
       },
     },
     account: {
       encryptOAuthTokens: true,
       updateAccountOnSignIn: true,
       additionalFields: {
-        workspaceId: { type: 'string', required: false, input: false },
-        status: { type: 'string', required: false, input: false },
-        scopes: { type: 'string[]', required: false, input: false },
-        connectorType: { type: 'string', required: false, input: false },
+        workspaceId: { type: "string", required: false, input: false },
+        status: { type: "string", required: false, input: false },
+        scopes: { type: "string[]", required: false, input: false },
+        connectorType: { type: "string", required: false, input: false },
       },
     },
     plugins: [
@@ -453,21 +453,21 @@ export function createBetterAuth(db: AuthDatabase, env: GardenAuthRuntime) {
         schema: {
           session: {
             fields: {
-              activeOrganizationId: 'activeOrganizationId',
+              activeOrganizationId: "activeOrganizationId",
             },
           },
           organization: {
             fields: {
-              createdAt: 'createdAt',
-              logo: 'logo',
-              metadata: 'metadata',
+              createdAt: "createdAt",
+              logo: "logo",
+              metadata: "metadata",
             },
             additionalFields: {
-              description: { type: 'string', required: false, input: true },
-              context: { type: 'string', required: false, input: true },
-              settings: { type: 'json', required: false, input: true },
-              plan: { type: 'string', required: false, input: true },
-              updatedAt: { type: 'date', required: false },
+              description: { type: "string", required: false, input: true },
+              context: { type: "string", required: false, input: true },
+              settings: { type: "json", required: false, input: true },
+              plan: { type: "string", required: false, input: true },
+              updatedAt: { type: "date", required: false },
             },
           },
         },
@@ -478,28 +478,28 @@ export function createBetterAuth(db: AuthDatabase, env: GardenAuthRuntime) {
     ],
     hooks: {
       after: createAuthMiddleware(async (context) => {
-        if (context.path !== '/oauth2/callback/:providerId') {
-          return
+        if (context.path !== "/oauth2/callback/:providerId") {
+          return;
         }
 
         const providerId =
-          typeof context.params?.providerId === 'string'
+          typeof context.params?.providerId === "string"
             ? context.params.providerId
-            : undefined
-        const connector = getConnectorByProviderId(providerId)
-        const session = readHookSession(context as HookContext)
-        const workspaceId = session?.session.activeOrganizationId
-        const userId = session?.user.id
+            : undefined;
+        const connector = getConnectorByProviderId(providerId);
+        const session = readHookSession(context as HookContext);
+        const workspaceId = session?.session.activeOrganizationId;
+        const userId = session?.user.id;
 
         if (!providerId || !connector || !workspaceId || !userId) {
-          return
+          return;
         }
 
-        const oauthState = await getOAuthState()
+        const oauthState = await getOAuthState();
         const { flowId } = readOAuthCallbackFlow(
           oauthState?.callbackURL,
           baseURL,
-        )
+        );
         const result = await finishOAuthConnectorCallback({
           db,
           userId,
@@ -508,7 +508,7 @@ export function createBetterAuth(db: AuthDatabase, env: GardenAuthRuntime) {
           connectorId: connector.id,
           connectorLabel: connector.label,
           flowId,
-        })
+        });
 
         result.match({
           ok: ({ event, outcome }) => {
@@ -523,22 +523,22 @@ export function createBetterAuth(db: AuthDatabase, env: GardenAuthRuntime) {
                   provider_id: providerId,
                   callback_event_id: event.id,
                   flow_id: flowId,
-                  source: 'oauth',
+                  source: "oauth",
                   outcome: outcome.status,
                   stage: outcome.stage,
                   error_code: outcome.errorCode,
                 },
-              })
+              });
             }
 
-            if (outcome.status === 'degraded') {
+            if (outcome.status === "degraded") {
               context.context.logger.error(outcome.message, {
                 connectorId: connector.id,
                 providerId,
                 userId,
                 workspaceId,
                 errorCode: outcome.errorCode,
-              })
+              });
             }
           },
           err: (error) =>
@@ -550,12 +550,12 @@ export function createBetterAuth(db: AuthDatabase, env: GardenAuthRuntime) {
                     workspaceId,
                     error: databaseError,
                     properties: {
-                      operation: 'connector_callback',
+                      operation: "connector_callback",
                       connector_id: connector.id,
                       provider_id: providerId,
-                      stage: 'callback_persistence',
+                      stage: "callback_persistence",
                     },
-                  })
+                  });
                 }
                 context.context.logger.error(
                   databaseError.message,
@@ -566,26 +566,26 @@ export function createBetterAuth(db: AuthDatabase, env: GardenAuthRuntime) {
                     userId,
                     workspaceId,
                   },
-                )
+                );
               },
             }),
-        })
+        });
       }),
     },
     user: {
       fields: {
-        image: 'avatarUrl',
-        emailVerified: 'emailVerified',
-        createdAt: 'createdAt',
-        updatedAt: 'updatedAt',
+        image: "avatarUrl",
+        emailVerified: "emailVerified",
+        createdAt: "createdAt",
+        updatedAt: "updatedAt",
       },
     },
     advanced: {
       disableCSRFCheck: false,
       disableOriginCheck: false,
       database: {
-        generateId: () => crypto.randomUUID(),
+        generateId: "uuid",
       },
     },
-  })
+  });
 }

--- a/apps/web/src/lib/invitation-flow.ts
+++ b/apps/web/src/lib/invitation-flow.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod'
+
+/**
+ * Client-safe invitation-flow vocabulary shared by routes and server
+ * functions. Lives outside `lib/server/invitations.ts` on purpose: TanStack
+ * Start only strips a server module from the browser bundle when every export
+ * is a server function (see lib/server/route-session.ts transform). Mixing
+ * plain value exports into that module shipped its server imports
+ * (db → @garden/db/runtime → pg) to the browser, where `pg` crashes module
+ * evaluation with "Buffer is not defined". Keep this module free of
+ * server-only imports.
+ */
+
+export type SignupInvitationPreview = {
+  email: string
+  id: string
+  organizationName?: string
+  status: 'pending' | 'accepted' | 'rejected' | 'canceled' | 'expired'
+  userExists: boolean
+} | null
+
+/**
+ * Why an invite cannot complete, split so the route can show actionable copy
+ * instead of one generic failure. `configuration` covers Better Auth setup
+ * drift (for example the email-verification gate tripping again); `temporary`
+ * covers transient accept failures worth a retry.
+ */
+export type InvitationUnavailableReason =
+  | 'malformed'
+  | 'not_found'
+  | 'used'
+  | 'canceled'
+  | 'rejected'
+  | 'expired'
+  | 'workspace_full'
+  | 'configuration'
+  | 'temporary'
+
+export type InvitationAutoAcceptResult =
+  | { status: 'accepted'; workspaceId: string }
+  | {
+      status: 'email_mismatch'
+      invitationEmail: string
+      organizationName?: string
+      sessionEmail: string
+    }
+  | {
+      status: 'unavailable'
+      reason: InvitationUnavailableReason
+      message: string
+    }
+
+export const invitationUnavailableMessages: Record<
+  InvitationUnavailableReason,
+  string
+> = {
+  malformed:
+    'This invitation link is malformed. Ask an admin to resend the invite.',
+  not_found:
+    'Invitation not found. It may have been removed — ask an admin for a new invite.',
+  used: 'This invitation was already accepted. Sign in with the invited account to open the workspace.',
+  canceled:
+    'This invitation was canceled. Ask an admin for a new invite if you still need access.',
+  rejected:
+    'This invitation was declined. Ask an admin for a new invite if this was a mistake.',
+  expired:
+    'This invitation has expired. Ask an admin for a fresh invite — resending extends the same invite.',
+  workspace_full:
+    'This workspace has reached its member limit. Ask an admin to make room before inviting you again.',
+  configuration:
+    'This workspace cannot accept invitations right now because of a configuration problem. Ask an admin to contact Garden support.',
+  temporary:
+    'We could not accept this invitation right now. Try again in a moment, or ask an admin for a fresh invite.',
+}
+
+/** Extracts a Garden invitation id from a sanitized internal redirect target. */
+export function invitationIdFromRedirect(redirectTarget: string | undefined) {
+  if (!redirectTarget) return null
+  const url = new URL(redirectTarget, 'https://garden.local')
+  const match = /^\/invitations\/([^/]+)$/.exec(url.pathname)
+  const id = match?.[1]
+  if (!id || !z.string().uuid().safeParse(id).success) return null
+  return id
+}

--- a/apps/web/src/lib/invitation-flow.ts
+++ b/apps/web/src/lib/invitation-flow.ts
@@ -76,7 +76,9 @@ export const invitationUnavailableMessages: Record<
 /** Extracts a Garden invitation id from a sanitized internal redirect target. */
 export function invitationIdFromRedirect(redirectTarget: string | undefined) {
   if (!redirectTarget) return null
-  const url = new URL(redirectTarget, 'https://garden.local')
+  const internalBase = new URL('https://garden.local')
+  const url = new URL(redirectTarget, internalBase)
+  if (url.origin !== internalBase.origin) return null
   const match = /^\/invitations\/([^/]+)$/.exec(url.pathname)
   const id = match?.[1]
   if (!id || !z.string().uuid().safeParse(id).success) return null

--- a/apps/web/src/lib/server/invitation-acceptance.ts
+++ b/apps/web/src/lib/server/invitation-acceptance.ts
@@ -188,6 +188,15 @@ export async function acceptInvitationWithSession(args: {
     organizationName: row.organizationName,
   })
 
+  if (invitation.email.toLowerCase() !== session.user.email.toLowerCase()) {
+    return {
+      status: 'email_mismatch',
+      invitationEmail: invitation.email,
+      organizationName: invitation.organizationName,
+      sessionEmail: session.user.email,
+    }
+  }
+
   const existingMembership = await findInvitationMembership({
     db,
     organizationId: invitation.organizationId,
@@ -229,15 +238,6 @@ export async function acceptInvitationWithSession(args: {
       status: 'unavailable',
       reason: 'expired',
       message: invitationUnavailableMessages.expired,
-    }
-  }
-
-  if (invitation.email.toLowerCase() !== session.user.email.toLowerCase()) {
-    return {
-      status: 'email_mismatch',
-      invitationEmail: invitation.email,
-      organizationName: invitation.organizationName,
-      sessionEmail: session.user.email,
     }
   }
 

--- a/apps/web/src/lib/server/invitation-acceptance.ts
+++ b/apps/web/src/lib/server/invitation-acceptance.ts
@@ -1,0 +1,315 @@
+import { and, eq } from 'drizzle-orm'
+import { Result, TaggedError } from 'better-result'
+import { createLogger } from '@garden/observability/console'
+import type { GardenAuth, GardenAuthSession } from '@/lib/server/context'
+import { schema, type Db } from '@/lib/server/db'
+import { toInvitation } from '@/lib/server/control-plane'
+import {
+  invitationUnavailableMessages,
+  type InvitationAutoAcceptResult,
+  type InvitationUnavailableReason,
+} from '@/lib/invitation-flow'
+
+const logger = createLogger('invitations')
+
+class InvitationAcceptError extends TaggedError('InvitationAcceptError')<{
+  cause: unknown
+  message: string
+}>() {}
+
+/**
+ * Finds existing organization membership before or after Better Auth invite
+ * acceptance. PostHog showed duplicate `member` inserts from `/invitations/*`:
+ * Better Auth updates an invite to accepted, then inserts a member, so a repeat
+ * accept can throw on Garden's unique organization/user index. Keeping this
+ * lookup local makes invite accept idempotent while still using Better Auth for
+ * normal session cookie updates. References: Better Auth `acceptInvitation` in
+ * `crud-invites.mjs` and better-result Result docs.
+ */
+async function findInvitationMembership(args: {
+  db: Db
+  organizationId: string
+  userId: string
+}) {
+  const [membership] = await args.db
+    .select({ organizationId: schema.member.organizationId })
+    .from(schema.member)
+    .where(
+      and(
+        eq(schema.member.organizationId, args.organizationId),
+        eq(schema.member.userId, args.userId),
+      ),
+    )
+    .limit(1)
+
+  return membership ?? null
+}
+
+/**
+ * Marks an invite consumed when membership already exists. Better Auth accepts
+ * pending invites by mutating invitation status before inserting `member`; when
+ * the member already exists, that insert can 500 and leave product UX broken.
+ * This helper preserves the intended after-state for repeat clicks and races:
+ * invitation is accepted, active organization is refreshed, and the route can
+ * redirect to the workspace instead of showing an error. The status update is
+ * restricted to rows still `pending` so a concurrent cancelInvitation can never
+ * be resurrected back to accepted by this recovery path.
+ */
+async function activateExistingInvitationMembership(args: {
+  auth: GardenAuth
+  db: Db
+  headers: Headers
+  invitationId: string
+  organizationId: string
+  forwardResponseHeaders?: (headers: Headers) => void
+}) {
+  await args.db
+    .update(schema.invitation)
+    .set({ status: 'accepted' })
+    .where(
+      and(
+        eq(schema.invitation.id, args.invitationId),
+        eq(schema.invitation.status, 'pending'),
+      ),
+    )
+
+  await activateWorkspace(args)
+}
+
+/**
+ * Sets Better Auth's active organization and forwards the refreshed session
+ * cookie. Better Auth's org adapter only updates the session row in Postgres;
+ * with `session.cookieCache` (compact strategy) enabled the browser keeps a
+ * stale `session_data` cookie whose activeOrganizationId predates acceptance,
+ * so later requests without an explicit `workspace_id` would resolve the wrong
+ * workspace. The set-active endpoint rewrites that cookie — but `auth.api.*`
+ * calls run server-side, so without forwarding, the Set-Cookie never reaches
+ * the browser. References: better-auth crud-org.mjs set-active (calls
+ * setSessionCookie), @tanstack/start-server-core setResponseHeader.
+ */
+async function activateWorkspace(args: {
+  auth: GardenAuth
+  headers: Headers
+  organizationId: string
+  forwardResponseHeaders?: (headers: Headers) => void
+}) {
+  const result = await Result.tryPromise({
+    try: async () =>
+      (await args.auth.api.setActiveOrganization({
+        headers: args.headers,
+        body: { organizationId: args.organizationId },
+        returnHeaders: true,
+      })) as { headers: Headers; response: unknown },
+    catch: (cause) => cause,
+  })
+
+  if (result.isErr()) {
+    logger.error('invitation.activate_workspace_failed', {
+      organizationId: args.organizationId,
+      errorMessage:
+        result.error instanceof Error
+          ? result.error.message
+          : String(result.error),
+    })
+    return
+  }
+
+  if (result.value.headers.getSetCookie().length > 0) {
+    args.forwardResponseHeaders?.(result.value.headers)
+  }
+}
+
+/** Reads the machine code Better Auth attaches to thrown APIErrors. */
+function readApiErrorCode(cause: unknown) {
+  if (cause && typeof cause === 'object' && 'body' in cause) {
+    const body = (cause as { body?: { code?: unknown } }).body
+    if (body && typeof body.code === 'string') return body.code
+  }
+  return undefined
+}
+
+/**
+ * Maps Better Auth accept failures to product outcomes. Source of codes:
+ * better-auth 1.6.26 organization error-codes.mjs and the acceptInvitation
+ * route in crud-invites.mjs.
+ */
+function reasonFromAcceptError(cause: unknown): InvitationUnavailableReason {
+  switch (readApiErrorCode(cause)) {
+    case 'INVITATION_NOT_FOUND':
+      return 'not_found'
+    case 'ORGANIZATION_MEMBERSHIP_LIMIT_REACHED':
+      return 'workspace_full'
+    case 'EMAIL_VERIFICATION_REQUIRED_BEFORE_ACCEPTING_OR_REJECTING_INVITATION':
+      return 'configuration'
+    default:
+      return 'temporary'
+  }
+}
+
+/**
+ * Core invite acceptance, exported so integration tests can drive it with a
+ * real Better Auth instance and session cookie against isolated Postgres.
+ * Order matters: membership is checked before invitation status so repeat
+ * clicks on an already-accepted link reopen the workspace instead of failing,
+ * while canceled/expired invites still stop sessions that never joined.
+ */
+export async function acceptInvitationWithSession(args: {
+  auth: GardenAuth
+  db: Db
+  requestHeaders: Headers
+  session: NonNullable<GardenAuthSession>
+  invitationId: string
+  forwardResponseHeaders?: (headers: Headers) => void
+}): Promise<InvitationAutoAcceptResult> {
+  const { db, session } = args
+  const [row] = await db
+    .select({
+      invitation: schema.invitation,
+      organizationName: schema.organization.name,
+    })
+    .from(schema.invitation)
+    .leftJoin(
+      schema.organization,
+      eq(schema.organization.id, schema.invitation.organizationId),
+    )
+    .where(eq(schema.invitation.id, args.invitationId))
+    .limit(1)
+
+  if (!row) {
+    return {
+      status: 'unavailable',
+      reason: 'not_found',
+      message: invitationUnavailableMessages.not_found,
+    }
+  }
+
+  const invitation = toInvitation({
+    ...row.invitation,
+    organizationName: row.organizationName,
+  })
+
+  const existingMembership = await findInvitationMembership({
+    db,
+    organizationId: invitation.organizationId,
+    userId: session.user.id,
+  })
+
+  if (existingMembership) {
+    await activateExistingInvitationMembership({
+      auth: args.auth,
+      db,
+      headers: args.requestHeaders,
+      invitationId: args.invitationId,
+      organizationId: invitation.organizationId,
+      forwardResponseHeaders: args.forwardResponseHeaders,
+    })
+
+    return {
+      status: 'accepted',
+      workspaceId: invitation.organizationId,
+    }
+  }
+
+  if (invitation.status !== 'pending') {
+    const reason =
+      invitation.status === 'accepted'
+        ? 'used'
+        : invitation.status === 'canceled'
+          ? 'canceled'
+          : 'rejected'
+    return {
+      status: 'unavailable',
+      reason,
+      message: invitationUnavailableMessages[reason],
+    }
+  }
+
+  if (new Date(invitation.expiresAt).getTime() <= Date.now()) {
+    return {
+      status: 'unavailable',
+      reason: 'expired',
+      message: invitationUnavailableMessages.expired,
+    }
+  }
+
+  if (invitation.email.toLowerCase() !== session.user.email.toLowerCase()) {
+    return {
+      status: 'email_mismatch',
+      invitationEmail: invitation.email,
+      organizationName: invitation.organizationName,
+      sessionEmail: session.user.email,
+    }
+  }
+
+  const acceptResult = await Result.tryPromise({
+    try: async () =>
+      (await args.auth.api.acceptInvitation({
+        headers: args.requestHeaders,
+        body: {
+          invitationId: args.invitationId,
+        },
+      })) as { member: { organizationId: string } },
+    catch: (cause) =>
+      new InvitationAcceptError({
+        cause,
+        message:
+          cause instanceof Error
+            ? cause.message
+            : 'Failed to accept invitation.',
+      }),
+  })
+
+  return await acceptResult.match({
+    ok: async (result): Promise<InvitationAutoAcceptResult> => {
+      await activateWorkspace({
+        auth: args.auth,
+        headers: args.requestHeaders,
+        organizationId: result.member.organizationId,
+        forwardResponseHeaders: args.forwardResponseHeaders,
+      })
+
+      return {
+        status: 'accepted' as const,
+        workspaceId: result.member.organizationId,
+      }
+    },
+    err: async (error): Promise<InvitationAutoAcceptResult> => {
+      const recoveredMembership = await findInvitationMembership({
+        db,
+        organizationId: invitation.organizationId,
+        userId: session.user.id,
+      })
+
+      if (recoveredMembership) {
+        await activateExistingInvitationMembership({
+          auth: args.auth,
+          db,
+          headers: args.requestHeaders,
+          invitationId: args.invitationId,
+          organizationId: invitation.organizationId,
+          forwardResponseHeaders: args.forwardResponseHeaders,
+        })
+
+        return {
+          status: 'accepted' as const,
+          workspaceId: invitation.organizationId,
+        }
+      }
+
+      const reason = reasonFromAcceptError(error.cause)
+      logger.error('invitation.accept_failed', {
+        invitationId: args.invitationId,
+        organizationId: invitation.organizationId,
+        reason,
+        errorMessage: error.message,
+        errorCode: readApiErrorCode(error.cause) ?? null,
+      })
+
+      return {
+        status: 'unavailable' as const,
+        reason,
+        message: invitationUnavailableMessages[reason],
+      }
+    },
+  })
+}

--- a/apps/web/src/lib/server/invitations.integration.test.ts
+++ b/apps/web/src/lib/server/invitations.integration.test.ts
@@ -1,0 +1,405 @@
+import { randomUUID } from 'node:crypto'
+import { and, eq } from 'drizzle-orm'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import * as schema from '@garden/db/schema'
+import { startTestDb, type TestDb } from '@garden/db/testing'
+import { createBetterAuth } from '@/lib/auth/instance'
+import { invitationIdFromRedirect } from '@/lib/invitation-flow'
+import { acceptInvitationWithSession } from './invitation-acceptance'
+
+// Match @garden/db's measured testcontainer lifecycle budget. Under the full
+// workspace run, concurrent container startup can exceed Vitest's 10s default.
+const TEST_DB_HOOK_TIMEOUT_MS = 120_000
+
+const FUTURE = () => new Date(Date.now() + 48 * 3600 * 1000)
+const PAST = () => new Date(Date.now() - 3600 * 1000)
+
+type Auth = ReturnType<typeof createBetterAuth>
+
+type SessionContext = {
+  requestHeaders: Headers
+  session: NonNullable<Awaited<ReturnType<Auth['api']['getSession']>>>
+}
+
+/**
+ * Signs a user up through the real Better Auth instance and captures the
+ * session cookies exactly as a browser would send them back. Invitation
+ * acceptance depends on those cookies (session lookup + refreshed
+ * session_data), so tests must not fabricate session rows by hand.
+ */
+async function signUpUser(auth: Auth, email: string): Promise<SessionContext> {
+  const result = (await auth.api.signUpEmail({
+    body: { name: 'Invitee', email, password: 'correct-horse-9' },
+    returnHeaders: true,
+  })) as { headers: Headers }
+
+  const cookie = result.headers
+    .getSetCookie()
+    .map((entry) => entry.split(';')[0])
+    .join('; ')
+  const requestHeaders = new Headers({ cookie })
+  const session = await auth.api.getSession({ headers: requestHeaders })
+  if (!session) throw new Error('expected a session immediately after sign-up')
+
+  return { requestHeaders, session }
+}
+
+async function seedOrganization(testDb: TestDb, suffix: string) {
+  const [org] = await testDb.db
+    .insert(schema.organization)
+    .values({ name: 'Acme', slug: `acme-${suffix}` })
+    .returning()
+  const [inviter] = await testDb.db
+    .insert(schema.user)
+    .values({ email: `inviter-${suffix}@example.com`, name: 'Inviter' })
+    .returning()
+
+  return { org, inviter }
+}
+
+async function seedInvitation(
+  testDb: TestDb,
+  args: {
+    organizationId: string
+    inviterId: string
+    email: string
+    status?: 'pending' | 'accepted' | 'rejected' | 'canceled'
+    expiresAt?: Date
+  },
+) {
+  const [invitation] = await testDb.db
+    .insert(schema.invitation)
+    .values({
+      organizationId: args.organizationId,
+      inviterId: args.inviterId,
+      email: args.email,
+      role: 'member',
+      status: args.status ?? 'pending',
+      expiresAt: args.expiresAt ?? FUTURE(),
+    })
+    .returning()
+
+  return invitation
+}
+
+async function readInvitation(testDb: TestDb, invitationId: string) {
+  const [row] = await testDb.db
+    .select()
+    .from(schema.invitation)
+    .where(eq(schema.invitation.id, invitationId))
+    .limit(1)
+  return row
+}
+
+async function readMemberships(
+  testDb: TestDb,
+  args: { organizationId: string; userId: string },
+) {
+  return testDb.db
+    .select()
+    .from(schema.member)
+    .where(
+      and(
+        eq(schema.member.organizationId, args.organizationId),
+        eq(schema.member.userId, args.userId),
+      ),
+    )
+}
+
+describe('invitation acceptance (integration)', () => {
+  let testDb: TestDb
+  let auth: Auth
+
+  beforeAll(async () => {
+    testDb = await startTestDb()
+    auth = createBetterAuth(testDb.db, {
+      BETTER_AUTH_SECRET: 'test-secret-test-secret-test-secret',
+      BETTER_AUTH_URL: 'http://localhost:3000',
+    } as Parameters<typeof createBetterAuth>[1])
+  }, TEST_DB_HOOK_TIMEOUT_MS)
+
+  afterAll(async () => {
+    await testDb?.cleanup()
+  }, TEST_DB_HOOK_TIMEOUT_MS)
+
+  it('lets a fresh unverified password user accept a valid invite', async () => {
+    const suffix = randomUUID()
+    const { org, inviter } = await seedOrganization(testDb, suffix)
+    const inviteeEmail = `invitee-${suffix}@example.com`
+    const invitation = await seedInvitation(testDb, {
+      organizationId: org.id,
+      inviterId: inviter.id,
+      email: inviteeEmail,
+    })
+    const { requestHeaders, session } = await signUpUser(auth, inviteeEmail)
+
+    // Regression precondition: Garden has no email verification flow, so this
+    // is exactly the account state that used to be rejected.
+    expect(session.user.emailVerified).toBe(false)
+
+    const result = await acceptInvitationWithSession({
+      auth,
+      db: testDb.db,
+      requestHeaders,
+      session,
+      invitationId: invitation.id,
+    })
+
+    expect(result).toEqual({ status: 'accepted', workspaceId: org.id })
+    expect(
+      await readMemberships(testDb, {
+        organizationId: org.id,
+        userId: session.user.id,
+      }),
+    ).toHaveLength(1)
+    expect((await readInvitation(testDb, invitation.id))?.status).toBe(
+      'accepted',
+    )
+  })
+
+  it('keeps repeat acceptance idempotent and activates the workspace', async () => {
+    const suffix = randomUUID()
+    const { org, inviter } = await seedOrganization(testDb, suffix)
+    const inviteeEmail = `invitee-${suffix}@example.com`
+    const invitation = await seedInvitation(testDb, {
+      organizationId: org.id,
+      inviterId: inviter.id,
+      email: inviteeEmail,
+    })
+    const { requestHeaders, session } = await signUpUser(auth, inviteeEmail)
+
+    const first = await acceptInvitationWithSession({
+      auth,
+      db: testDb.db,
+      requestHeaders,
+      session,
+      invitationId: invitation.id,
+    })
+    const second = await acceptInvitationWithSession({
+      auth,
+      db: testDb.db,
+      requestHeaders,
+      session,
+      invitationId: invitation.id,
+    })
+
+    expect(first).toEqual({ status: 'accepted', workspaceId: org.id })
+    expect(second).toEqual({ status: 'accepted', workspaceId: org.id })
+    expect(
+      await readMemberships(testDb, {
+        organizationId: org.id,
+        userId: session.user.id,
+      }),
+    ).toHaveLength(1)
+
+    const [sessionRow] = await testDb.db
+      .select()
+      .from(schema.session)
+      .where(eq(schema.session.token, session.session.token))
+      .limit(1)
+    expect(sessionRow?.activeOrganizationId).toBe(org.id)
+  })
+
+  it('stops wrong-email sessions without touching the invite', async () => {
+    const suffix = randomUUID()
+    const { org, inviter } = await seedOrganization(testDb, suffix)
+    const invitation = await seedInvitation(testDb, {
+      organizationId: org.id,
+      inviterId: inviter.id,
+      email: `invitee-${suffix}@example.com`,
+    })
+    const otherEmail = `other-${suffix}@example.com`
+    const { requestHeaders, session } = await signUpUser(auth, otherEmail)
+
+    const result = await acceptInvitationWithSession({
+      auth,
+      db: testDb.db,
+      requestHeaders,
+      session,
+      invitationId: invitation.id,
+    })
+
+    expect(result).toEqual({
+      status: 'email_mismatch',
+      invitationEmail: invitation.email,
+      organizationName: 'Acme',
+      sessionEmail: otherEmail,
+    })
+    expect(
+      await readMemberships(testDb, {
+        organizationId: org.id,
+        userId: session.user.id,
+      }),
+    ).toHaveLength(0)
+    expect((await readInvitation(testDb, invitation.id))?.status).toBe(
+      'pending',
+    )
+  })
+
+  it.each([
+    {
+      name: 'expired',
+      seed: { expiresAt: PAST() } as const,
+      reason: 'expired',
+    },
+    {
+      name: 'canceled',
+      seed: { status: 'canceled' } as const,
+      reason: 'canceled',
+    },
+    {
+      name: 'rejected',
+      seed: { status: 'rejected' } as const,
+      reason: 'rejected',
+    },
+    {
+      name: 'accepted without membership',
+      seed: { status: 'accepted' } as const,
+      reason: 'used',
+    },
+  ])('marks $name invites unavailable with a distinct reason', async ({
+    seed,
+    reason,
+  }) => {
+    const suffix = randomUUID()
+    const { org, inviter } = await seedOrganization(testDb, suffix)
+    const inviteeEmail = `invitee-${suffix}@example.com`
+    const invitation = await seedInvitation(testDb, {
+      organizationId: org.id,
+      inviterId: inviter.id,
+      email: inviteeEmail,
+      ...seed,
+    })
+    const { requestHeaders, session } = await signUpUser(auth, inviteeEmail)
+
+    const result = await acceptInvitationWithSession({
+      auth,
+      db: testDb.db,
+      requestHeaders,
+      session,
+      invitationId: invitation.id,
+    })
+
+    expect(result.status).toBe('unavailable')
+    if (result.status === 'unavailable') expect(result.reason).toBe(reason)
+    expect(
+      await readMemberships(testDb, {
+        organizationId: org.id,
+        userId: session.user.id,
+      }),
+    ).toHaveLength(0)
+  })
+
+  it('reports unknown invitation ids as not found', async () => {
+    const suffix = randomUUID()
+    const { requestHeaders, session } = await signUpUser(
+      auth,
+      `invitee-${suffix}@example.com`,
+    )
+
+    const result = await acceptInvitationWithSession({
+      auth,
+      db: testDb.db,
+      requestHeaders,
+      session,
+      invitationId: randomUUID(),
+    })
+
+    expect(result.status).toBe('unavailable')
+    if (result.status === 'unavailable') expect(result.reason).toBe('not_found')
+  })
+
+  it('maps Better Auth membership-limit failures to workspace_full', async () => {
+    const suffix = randomUUID()
+    const { org, inviter } = await seedOrganization(testDb, suffix)
+
+    // Better Auth's default membershipLimit is 100 (crud-invites.mjs).
+    const fillerUsers = await testDb.db
+      .insert(schema.user)
+      .values(
+        Array.from({ length: 100 }, (_, index) => ({
+          email: `filler-${suffix}-${index}@example.com`,
+          name: 'Filler',
+        })),
+      )
+      .returning()
+    await testDb.db.insert(schema.member).values(
+      fillerUsers.map((filler) => ({
+        organizationId: org.id,
+        userId: filler.id,
+        role: 'member',
+      })),
+    )
+
+    const inviteeEmail = `invitee-${suffix}@example.com`
+    const invitation = await seedInvitation(testDb, {
+      organizationId: org.id,
+      inviterId: inviter.id,
+      email: inviteeEmail,
+    })
+    const { requestHeaders, session } = await signUpUser(auth, inviteeEmail)
+
+    const result = await acceptInvitationWithSession({
+      auth,
+      db: testDb.db,
+      requestHeaders,
+      session,
+      invitationId: invitation.id,
+    })
+
+    expect(result.status).toBe('unavailable')
+    if (result.status === 'unavailable') {
+      expect(result.reason).toBe('workspace_full')
+    }
+  })
+
+  it('never resurrects a concurrently canceled invite during recovery', async () => {
+    const suffix = randomUUID()
+    const { org, inviter } = await seedOrganization(testDb, suffix)
+    const inviteeEmail = `invitee-${suffix}@example.com`
+    const { requestHeaders, session } = await signUpUser(auth, inviteeEmail)
+
+    // Race fixture: membership exists (accept landed) but a cancel already
+    // flipped the invite out of pending before the recovery path ran.
+    await testDb.db.insert(schema.member).values({
+      organizationId: org.id,
+      userId: session.user.id,
+      role: 'member',
+    })
+    const invitation = await seedInvitation(testDb, {
+      organizationId: org.id,
+      inviterId: inviter.id,
+      email: inviteeEmail,
+      status: 'canceled',
+    })
+
+    const result = await acceptInvitationWithSession({
+      auth,
+      db: testDb.db,
+      requestHeaders,
+      session,
+      invitationId: invitation.id,
+    })
+
+    expect(result).toEqual({ status: 'accepted', workspaceId: org.id })
+    expect((await readInvitation(testDb, invitation.id))?.status).toBe(
+      'canceled',
+    )
+  })
+})
+
+describe('invitationIdFromRedirect', () => {
+  it('extracts uuid ids from invite redirects', () => {
+    const id = randomUUID()
+    expect(invitationIdFromRedirect(`/invitations/${id}`)).toBe(id)
+  })
+
+  it.each([
+    ['relative garbage', '/invitations/not-a-uuid'],
+    ['external url', 'https://evil.example/invitations/x'],
+    ['missing id', '/invitations/'],
+    ['undefined', undefined],
+  ])('rejects %s', (_name, target) => {
+    expect(invitationIdFromRedirect(target)).toBeNull()
+  })
+})

--- a/apps/web/src/lib/server/invitations.integration.test.ts
+++ b/apps/web/src/lib/server/invitations.integration.test.ts
@@ -236,6 +236,36 @@ describe('invitation acceptance (integration)', () => {
     )
   })
 
+  it('does not consume another email invite when the user is already a member', async () => {
+    const suffix = randomUUID()
+    const { org, inviter } = await seedOrganization(testDb, suffix)
+    const invitation = await seedInvitation(testDb, {
+      organizationId: org.id,
+      inviterId: inviter.id,
+      email: `invitee-${suffix}@example.com`,
+    })
+    const otherEmail = `member-${suffix}@example.com`
+    const { requestHeaders, session } = await signUpUser(auth, otherEmail)
+    await testDb.db.insert(schema.member).values({
+      organizationId: org.id,
+      userId: session.user.id,
+      role: 'member',
+    })
+
+    const result = await acceptInvitationWithSession({
+      auth,
+      db: testDb.db,
+      requestHeaders,
+      session,
+      invitationId: invitation.id,
+    })
+
+    expect(result.status).toBe('email_mismatch')
+    expect((await readInvitation(testDb, invitation.id))?.status).toBe(
+      'pending',
+    )
+  })
+
   it.each([
     {
       name: 'expired',
@@ -397,6 +427,7 @@ describe('invitationIdFromRedirect', () => {
   it.each([
     ['relative garbage', '/invitations/not-a-uuid'],
     ['external url', 'https://evil.example/invitations/x'],
+    ['backslash external url', `/\\evil.example/invitations/${randomUUID()}`],
     ['missing id', '/invitations/'],
     ['undefined', undefined],
   ])('rejects %s', (_name, target) => {

--- a/apps/web/src/lib/server/invitations.ts
+++ b/apps/web/src/lib/server/invitations.ts
@@ -1,46 +1,28 @@
-import { and, eq, sql } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 import { redirect } from '@tanstack/react-router'
-import { Result, TaggedError } from 'better-result'
 import { createServerFn } from '@tanstack/react-start'
+import { setResponseHeader } from '@tanstack/react-start/server'
 import { z } from 'zod'
-import { requireAppRequestContext, type GardenAuth } from '@/lib/server/context'
-import { schema, type Db } from '@/lib/server/db'
+import { requireAppRequestContext } from '@/lib/server/context'
+import { schema } from '@/lib/server/db'
 import { toInvitation } from '@/lib/server/control-plane'
-
-export type SignupInvitationPreview = {
-  email: string
-  id: string
-  organizationName?: string
-  status: 'pending' | 'accepted' | 'rejected' | 'canceled' | 'expired'
-  userExists: boolean
-} | null
+import { acceptInvitationWithSession } from '@/lib/server/invitation-acceptance'
+import type {
+  InvitationAutoAcceptResult,
+  SignupInvitationPreview,
+} from '@/lib/invitation-flow'
 
 const invitationInputSchema = z.object({
-  invitationId: z.string().min(1),
+  invitationId: z.string().uuid(),
 })
 
-class InvitationAcceptError extends TaggedError('InvitationAcceptError')<{
-  cause: unknown
-  message: string
-}>() {}
-
-export type InvitationAutoAcceptResult =
-  | { status: 'accepted'; workspaceId: string }
-  | {
-      status: 'email_mismatch'
-      invitationEmail: string
-      organizationName?: string
-      sessionEmail: string
-    }
-  | { status: 'unavailable'; message: string }
-
-/** Extracts a Garden invitation id from a sanitized internal redirect target. */
-export function invitationIdFromRedirect(redirectTarget: string | undefined) {
-  if (!redirectTarget) return null
-  const url = new URL(redirectTarget, 'https://garden.local')
-  const match = /^\/invitations\/([^/]+)$/.exec(url.pathname)
-  return match?.[1] ?? null
-}
+/**
+ * Every export of this module must stay a `createServerFn`. TanStack Start's
+ * vite plugin only strips a server module from the browser bundle when all
+ * exports are server functions (see route-session.ts); one plain value export
+ * ships the module's server imports (db → pg) to the browser. Shared
+ * invitation vocabulary lives in `@/lib/invitation-flow` instead.
+ */
 
 /**
  * Loads minimal invite data for auth routing without requiring a session. Better
@@ -110,60 +92,6 @@ function toSignupInvitationStatus(
 }
 
 /**
- * Finds existing organization membership before or after Better Auth invite
- * acceptance. PostHog showed duplicate `member` inserts from `/invitations/*`:
- * Better Auth updates an invite to accepted, then inserts a member, so a repeat
- * accept can throw on Garden's unique organization/user index. Keeping this
- * lookup local makes invite accept idempotent while still using Better Auth for
- * normal session cookie updates. References: Better Auth `acceptInvitation` in
- * `crud-invites.mjs` and better-result Result docs.
- */
-async function findInvitationMembership(args: {
-  db: Db
-  organizationId: string
-  userId: string
-}) {
-  const [membership] = await args.db
-    .select({ organizationId: schema.member.organizationId })
-    .from(schema.member)
-    .where(
-      and(
-        eq(schema.member.organizationId, args.organizationId),
-        eq(schema.member.userId, args.userId),
-      ),
-    )
-    .limit(1)
-
-  return membership ?? null
-}
-
-/**
- * Marks an invite consumed when membership already exists. Better Auth accepts
- * pending invites by mutating invitation status before inserting `member`; when
- * the member already exists, that insert can 500 and leave product UX broken.
- * This helper preserves the intended after-state for repeat clicks and races:
- * invitation is accepted, active organization is refreshed, and the route can
- * redirect to the workspace instead of showing an error.
- */
-async function activateExistingInvitationMembership(args: {
-  auth: GardenAuth
-  db: Db
-  headers: Headers
-  invitationId: string
-  organizationId: string
-}) {
-  await args.db
-    .update(schema.invitation)
-    .set({ status: 'accepted' })
-    .where(eq(schema.invitation.id, args.invitationId))
-
-  await args.auth.api.setActiveOrganization({
-    headers: args.headers,
-    body: { organizationId: args.organizationId },
-  })
-}
-
-/**
  * Accepts an invite for the current authenticated user only when the session
  * email matches the invitation email. This removes the redundant consent screen
  * on the email-link happy path while preserving a visible stop for account
@@ -181,125 +109,20 @@ export const acceptInvitationForCurrentUser = createServerFn({ method: 'POST' })
       })
     }
 
-    const db = await appContext.db()
-    const [row] = await db
-      .select({
-        invitation: schema.invitation,
-        organizationName: schema.organization.name,
-      })
-      .from(schema.invitation)
-      .leftJoin(
-        schema.organization,
-        eq(schema.organization.id, schema.invitation.organizationId),
-      )
-      .where(eq(schema.invitation.id, data.invitationId))
-      .limit(1)
-
-    if (!row) {
-      return { status: 'unavailable', message: 'Invitation not found.' }
-    }
-
-    const invitation = toInvitation({
-      ...row.invitation,
-      organizationName: row.organizationName,
-    })
-
-    if (invitation.status !== 'pending') {
-      return {
-        status: 'unavailable',
-        message: `This invitation is ${invitation.status}. Ask an admin for a new invite if you still need access.`,
-      }
-    }
-
-    if (new Date(invitation.expiresAt).getTime() <= Date.now()) {
-      return {
-        status: 'unavailable',
-        message: 'This invitation has expired. Ask an admin for a new invite.',
-      }
-    }
-
-    if (invitation.email.toLowerCase() !== session.user.email.toLowerCase()) {
-      return {
-        status: 'email_mismatch',
-        invitationEmail: invitation.email,
-        organizationName: invitation.organizationName,
-        sessionEmail: session.user.email,
-      }
-    }
-
-    const auth = await appContext.auth.getAuth()
-    const existingMembership = await findInvitationMembership({
-      db,
-      organizationId: invitation.organizationId,
-      userId: session.user.id,
-    })
-
-    if (existingMembership) {
-      await activateExistingInvitationMembership({
-        auth,
-        db,
-        headers: appContext.request.headers,
-        invitationId: data.invitationId,
-        organizationId: invitation.organizationId,
-      })
-
-      return {
-        status: 'accepted',
-        workspaceId: invitation.organizationId,
-      }
-    }
-
-    const acceptResult = await Result.tryPromise({
-      try: async () =>
-        (await auth.api.acceptInvitation({
-          headers: appContext.request.headers,
-          body: {
-            invitationId: data.invitationId,
-          },
-        })) as { member: { organizationId: string } },
-      catch: (cause) =>
-        new InvitationAcceptError({
-          cause,
-          message:
-            cause instanceof Error
-              ? cause.message
-              : 'Failed to accept invitation.',
-        }),
-    })
-
-    return await acceptResult.match({
-      ok: (result) =>
-        Promise.resolve({
-          status: 'accepted' as const,
-          workspaceId: result.member.organizationId,
-        }),
-      err: async () => {
-        const recoveredMembership = await findInvitationMembership({
-          db,
-          organizationId: invitation.organizationId,
-          userId: session.user.id,
-        })
-
-        if (recoveredMembership) {
-          await activateExistingInvitationMembership({
-            auth,
-            db,
-            headers: appContext.request.headers,
-            invitationId: data.invitationId,
-            organizationId: invitation.organizationId,
-          })
-
-          return {
-            status: 'accepted' as const,
-            workspaceId: invitation.organizationId,
-          }
-        }
-
-        return {
-          status: 'unavailable' as const,
-          message:
-            'We could not accept this invitation. Ask an admin for a fresh invite if you still need access.',
-        }
-      },
+    return acceptInvitationWithSession({
+      auth: await appContext.auth.getAuth(),
+      db: await appContext.db(),
+      requestHeaders: appContext.request.headers,
+      session,
+      invitationId: data.invitationId,
+      forwardResponseHeaders: forwardSetCookieHeaders,
     })
   })
+
+/** Copies Better Auth's Set-Cookie values onto the Start server-fn response. */
+function forwardSetCookieHeaders(headers: Headers) {
+  const cookies = headers.getSetCookie()
+  if (cookies.length > 0) {
+    setResponseHeader('set-cookie', cookies)
+  }
+}

--- a/apps/web/src/lib/server/validation/workspaces.ts
+++ b/apps/web/src/lib/server/validation/workspaces.ts
@@ -35,6 +35,12 @@ export const createWorkspaceMemberBodySchema = z
   .object({
     email: z.string().trim().email(),
     role: memberRoleSchema.optional(),
+    /**
+     * Idempotent re-send of an existing pending invitation. The route refreshes
+     * expiresAt on the existing row (covering expired invites, which Better
+     * Auth's own resend flag excludes) instead of creating a duplicate.
+     */
+    resend: z.boolean().optional(),
   })
   .strict()
 

--- a/apps/web/src/lib/server/workspace-permissions.ts
+++ b/apps/web/src/lib/server/workspace-permissions.ts
@@ -10,6 +10,7 @@ export const workspacePermissions = {
   agentManage: { agent: ['create', 'update', 'delete'] },
   connectionManage: { connection: ['update'] },
   issueManage: { issue: ['update'] },
+  invitationManage: { invitation: ['create', 'cancel'] },
   permissionManage: { permission: ['approve', 'grant'] },
   skillManage: { skill: ['create', 'update', 'delete'] },
 } satisfies Record<string, WorkspacePermission>

--- a/apps/web/src/routes/_authenticated/invitations/$id.tsx
+++ b/apps/web/src/routes/_authenticated/invitations/$id.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from 'react'
 import { useState } from 'react'
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
 import { MailQuestion } from 'lucide-react'
+import { Result } from 'better-result'
+import { toast } from 'sonner'
 import { z } from 'zod'
 import { Badge } from '@garden/ui/components/ui/badge'
 import { Button } from '@garden/ui/components/ui/button'
@@ -129,17 +131,27 @@ function SignOutAndContinueButton({ invitationId }: { invitationId: string }) {
   return (
     <Button
       disabled={pending}
-      onClick={() => {
+      onClick={async () => {
         setPending(true)
-        void authClient
-          .signOut()
-          .catch(() => undefined)
-          .finally(() =>
-            void navigate({
+        const requestResult = await Result.tryPromise({
+          try: () => authClient.signOut(),
+          catch: (cause) => cause,
+        })
+        const signOutResult = requestResult.andThen((response) =>
+          response.error ? Result.err(response.error) : Result.ok(undefined),
+        )
+
+        await signOutResult.match({
+          ok: () =>
+            navigate({
               to: '/login',
               search: { redirect: `/invitations/${invitationId}` },
             }),
-          )
+          err: async () => {
+            setPending(false)
+            toast.error('Could not sign out. Please try again.')
+          },
+        })
       }}
     >
       {pending ? 'Signing out...' : 'Sign out and continue'}

--- a/apps/web/src/routes/_authenticated/invitations/$id.tsx
+++ b/apps/web/src/routes/_authenticated/invitations/$id.tsx
@@ -1,12 +1,26 @@
 import type { ReactNode } from 'react'
+import { useState } from 'react'
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router'
 import { MailQuestion } from 'lucide-react'
+import { z } from 'zod'
 import { Badge } from '@garden/ui/components/ui/badge'
 import { Button } from '@garden/ui/components/ui/button'
+import { authClient } from '@/lib/auth/client'
+import { invitationUnavailableMessages } from '@/lib/invitation-flow'
 import { acceptInvitationForCurrentUser } from '@/lib/server/invitations'
 
 export const Route = createFileRoute('/_authenticated/invitations/$id')({
   loader: async ({ params }) => {
+    // Guard malformed ids here so the page renders the unavailable state
+    // instead of surfacing a server-fn validation throw.
+    if (!z.string().uuid().safeParse(params.id).success) {
+      return {
+        status: 'unavailable' as const,
+        reason: 'malformed' as const,
+        message: invitationUnavailableMessages.malformed,
+      }
+    }
+
     const result = await acceptInvitationForCurrentUser({
       data: { invitationId: params.id },
     })
@@ -36,6 +50,7 @@ export const Route = createFileRoute('/_authenticated/invitations/$id')({
  */
 function InvitationRoute() {
   const result = Route.useLoaderData()
+  const { id: invitationId } = Route.useParams()
   const navigate = useNavigate()
 
   if (result.status === 'email_mismatch') {
@@ -49,22 +64,25 @@ function InvitationRoute() {
             : `This invite is for ${result.invitationEmail}, but you are signed in as ${result.sessionEmail}. Sign out and create or use the invited account to join.`
         }
       >
-        <Button
-          className="mt-8"
-          onClick={() =>
-            void navigate({
-              to: '/workspace',
-              search: {
-                connector_flow: undefined,
-                connector_id: undefined,
-                workspace_id: undefined,
-                issue: undefined,
-              },
-            })
-          }
-        >
-          Back to workspace
-        </Button>
+        <div className="mt-8 flex flex-wrap items-center gap-3">
+          <SignOutAndContinueButton invitationId={invitationId} />
+          <Button
+            variant="outline"
+            onClick={() =>
+              void navigate({
+                to: '/workspace',
+                search: {
+                  connector_flow: undefined,
+                  connector_id: undefined,
+                  workspace_id: undefined,
+                  issue: undefined,
+                },
+              })
+            }
+          >
+            Back to workspace
+          </Button>
+        </div>
       </InvitationShell>
     )
   }
@@ -92,6 +110,40 @@ function InvitationRoute() {
         Back to workspace
       </Button>
     </InvitationShell>
+  )
+}
+
+/**
+ * One-click escape for the wrong-account state: signs the current session out
+ * and bounces to sign-in with the invite link preserved, so the user lands
+ * back in the locked invitation flow instead of a bare auth page. Deliberately
+ * bypasses the app-state auth store — its global onLogout callback hard-
+ * navigates to bare `/login` (web-providers.tsx), which would drop the invite
+ * redirect — and `@/lib/api/auth`, whose transport module chain hangs this
+ * route's SSR.
+ */
+function SignOutAndContinueButton({ invitationId }: { invitationId: string }) {
+  const navigate = useNavigate()
+  const [pending, setPending] = useState(false)
+
+  return (
+    <Button
+      disabled={pending}
+      onClick={() => {
+        setPending(true)
+        void authClient
+          .signOut()
+          .catch(() => undefined)
+          .finally(() =>
+            void navigate({
+              to: '/login',
+              search: { redirect: `/invitations/${invitationId}` },
+            }),
+          )
+      }}
+    >
+      {pending ? 'Signing out...' : 'Sign out and continue'}
+    </Button>
   )
 }
 

--- a/apps/web/src/routes/api/workspaces/$id/-members.test.ts
+++ b/apps/web/src/routes/api/workspaces/$id/-members.test.ts
@@ -1,0 +1,184 @@
+import type { AppRequestContext } from '@/lib/server/context'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Route } from './members'
+
+const mocks = vi.hoisted(() => ({
+  requireSession: vi.fn(),
+  requireWorkspacePermission: vi.fn(),
+  sendOrganizationInvitationEmail: vi.fn(),
+}))
+
+vi.mock('@/lib/server/control-plane', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/server/control-plane')>()
+  return { ...actual, requireSession: mocks.requireSession }
+})
+
+vi.mock('@/lib/server/workspace-permissions', () => ({
+  requireWorkspacePermission: mocks.requireWorkspacePermission,
+  workspacePermissions: {
+    invitationManage: { invitation: ['create', 'cancel'] },
+  },
+}))
+
+vi.mock('@/lib/server/email/invitation', () => ({
+  sendOrganizationInvitationEmail: mocks.sendOrganizationInvitationEmail,
+}))
+
+const workspaceId = '00000000-0000-4000-8000-000000000001'
+const invitationId = '00000000-0000-4000-8000-000000000002'
+const originalExpiry = new Date('2026-09-01T00:00:00.000Z')
+
+const invitation = {
+  id: invitationId,
+  organizationId: workspaceId,
+  inviterId: '00000000-0000-4000-8000-000000000003',
+  email: 'invitee@example.com',
+  role: 'member',
+  status: 'pending',
+  expiresAt: originalExpiry,
+}
+
+function getPostHandler() {
+  const handlers = Route.options.server?.handlers
+  if (!handlers || typeof handlers === 'function') {
+    throw new Error('Expected workspace member route handlers')
+  }
+  if (typeof handlers.POST !== 'function') {
+    throw new Error('Expected workspace member POST handler')
+  }
+  return handlers.POST
+}
+
+function resendRequest() {
+  return new Request(
+    `https://garden.test/api/workspaces/${workspaceId}/members`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: invitation.email, resend: true }),
+    },
+  )
+}
+
+function createDb(options: {
+  updatedRows?: Array<{ id: string }>
+  emailOrganization?: { name: string }
+}) {
+  const limit = vi
+    .fn()
+    .mockResolvedValueOnce([invitation])
+    .mockResolvedValueOnce([options.emailOrganization ?? { name: 'Acme' }])
+  const updatePayloads: Array<Record<string, unknown>> = []
+  const updatePredicates: unknown[] = []
+
+  const db = {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit })),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((payload: Record<string, unknown>) => {
+        updatePayloads.push(payload)
+        const updateIndex = updatePayloads.length
+        return {
+          where: vi.fn((predicate: unknown) => {
+            updatePredicates.push(predicate)
+            return updateIndex === 1
+              ? {
+                  returning: vi
+                    .fn()
+                    .mockResolvedValue(
+                      options.updatedRows ?? [{ id: invitationId }],
+                    ),
+                }
+              : Promise.resolve()
+          }),
+        }
+      }),
+    })),
+  }
+
+  return { db, updatePayloads, updatePredicates }
+}
+
+async function postResend(db: ReturnType<typeof createDb>['db']) {
+  const request = resendRequest()
+  const response = await getPostHandler()({
+    context: {
+      db: async () => db,
+      env: {},
+      auth: { getAuth: async () => ({ api: {} }) },
+    } as unknown as AppRequestContext,
+    request,
+    params: { id: workspaceId },
+    pathname: '/api/workspaces/$id/members',
+    next: () => ({ isNext: true, context: undefined }),
+  })
+  return { request, response }
+}
+
+describe('workspace invitation resend', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.requireSession.mockResolvedValue({
+      user: { email: 'admin@example.com', name: 'Admin' },
+    })
+    mocks.requireWorkspacePermission.mockResolvedValue(null)
+    mocks.sendOrganizationInvitationEmail.mockResolvedValue(undefined)
+  })
+
+  it('rejects a member without invite permission before reading the invite', async () => {
+    const { db } = createDb({})
+    mocks.requireWorkspacePermission.mockResolvedValueOnce(
+      Response.json({ error: 'Forbidden' }, { status: 403 }),
+    )
+
+    const { request, response } = await postResend(db)
+
+    expect(response?.status).toBe(403)
+    expect(mocks.requireWorkspacePermission).toHaveBeenCalledWith({
+      appContext: expect.anything(),
+      request,
+      workspaceId,
+      permissions: { invitation: ['create', 'cancel'] },
+    })
+    expect(db.select).not.toHaveBeenCalled()
+    expect(mocks.sendOrganizationInvitationEmail).not.toHaveBeenCalled()
+  })
+
+  it('refreshes the same pending invite and sends one email', async () => {
+    const { db, updatePayloads } = createDb({})
+
+    const { response } = await postResend(db)
+
+    expect(response?.status).toBe(200)
+    await expect(response?.json()).resolves.toMatchObject({ id: invitationId })
+    expect(updatePayloads).toHaveLength(1)
+    expect(updatePayloads[0]?.expiresAt).toBeInstanceOf(Date)
+    expect(mocks.sendOrganizationInvitationEmail).toHaveBeenCalledOnce()
+  })
+
+  it('does not email when the pending update loses a cancellation race', async () => {
+    const { db } = createDb({ updatedRows: [] })
+
+    const { response } = await postResend(db)
+
+    expect(response?.status).toBe(404)
+    expect(mocks.sendOrganizationInvitationEmail).not.toHaveBeenCalled()
+  })
+
+  it('restores the old expiry when email delivery fails', async () => {
+    const { db, updatePayloads } = createDb({})
+    mocks.sendOrganizationInvitationEmail.mockRejectedValueOnce(
+      new Error('delivery failed'),
+    )
+
+    const { response } = await postResend(db)
+
+    expect(response?.status).toBe(502)
+    expect(updatePayloads).toHaveLength(2)
+    expect(updatePayloads[1]).toEqual({ expiresAt: originalExpiry })
+  })
+})

--- a/apps/web/src/routes/api/workspaces/$id/members.ts
+++ b/apps/web/src/routes/api/workspaces/$id/members.ts
@@ -11,7 +11,6 @@ import {
   requireSession,
   toInvitation,
   unauthorized,
-  badRequest,
 } from '@/lib/server/control-plane'
 import { schema, type Db } from '@/lib/server/db'
 import { sendOrganizationInvitationEmail } from '@/lib/server/email/invitation'
@@ -334,7 +333,10 @@ export const Route = createFileRoute('/api/workspaces/$id/members')({
           ok: (invitation) => Response.json(invitation),
           err: (error) =>
             error instanceof WorkspaceInvitationRequestError
-              ? badRequest(error.message)
+              ? Response.json(
+                  { error: error.message },
+                  { status: error.status },
+                )
               : Response.json(
                   { error: error.message },
                   { status: error.status },

--- a/apps/web/src/routes/api/workspaces/$id/members.ts
+++ b/apps/web/src/routes/api/workspaces/$id/members.ts
@@ -15,6 +15,10 @@ import {
 } from '@/lib/server/control-plane'
 import { schema, type Db } from '@/lib/server/db'
 import { sendOrganizationInvitationEmail } from '@/lib/server/email/invitation'
+import {
+  requireWorkspacePermission,
+  workspacePermissions,
+} from '@/lib/server/workspace-permissions'
 
 const logger = createLogger('workspace-members-api')
 
@@ -175,6 +179,21 @@ export const Route = createFileRoute('/api/workspaces/$id/members')({
            * default 48h window), but covering expired rows too.
            */
           if (body.resend) {
+            const permissionResponse = await requireWorkspacePermission({
+              appContext,
+              request,
+              workspaceId: params.id,
+              permissions: workspacePermissions.invitationManage,
+            })
+            if (permissionResponse) {
+              return Result.err(
+                new WorkspaceInvitationRequestError({
+                  message: 'You cannot manage invitations in this workspace',
+                  status: permissionResponse.status,
+                }),
+              )
+            }
+
             const [existing] = await db
               .select()
               .from(schema.invitation)
@@ -187,31 +206,63 @@ export const Route = createFileRoute('/api/workspaces/$id/members')({
               )
               .limit(1)
 
-            if (existing) {
-              // Mirrors Better Auth's invitationExpiresIn default (48h).
-              const refreshedExpiry = new Date(Date.now() + 48 * 3600 * 1000)
+            if (!existing) {
+              return Result.err(
+                new WorkspaceInvitationRequestError({
+                  message: 'Pending invitation not found',
+                  status: 404,
+                }),
+              )
+            }
+
+            // Mirrors Better Auth's invitationExpiresIn default (48h).
+            const refreshedExpiry = new Date(Date.now() + 48 * 3600 * 1000)
+            const [updated] = await db
+              .update(schema.invitation)
+              .set({ expiresAt: refreshedExpiry })
+              .where(
+                and(
+                  eq(schema.invitation.id, existing.id),
+                  eq(schema.invitation.status, 'pending'),
+                ),
+              )
+              .returning({ id: schema.invitation.id })
+
+            if (!updated) {
+              return Result.err(
+                new WorkspaceInvitationRequestError({
+                  message: 'Pending invitation not found',
+                  status: 404,
+                }),
+              )
+            }
+
+            const refreshed = { ...existing, expiresAt: refreshedExpiry }
+            const resendEmailResult = await sendInvitationForRoute({
+              baseURL: new URL(request.url).origin,
+              db,
+              env: appContext.env,
+              invitation: refreshed,
+              inviter: {
+                email: session.user.email,
+                name: session.user.name,
+              },
+            })
+            if (resendEmailResult.isErr()) {
               await db
                 .update(schema.invitation)
-                .set({ expiresAt: refreshedExpiry })
-                .where(eq(schema.invitation.id, existing.id))
-
-              const refreshed = { ...existing, expiresAt: refreshedExpiry }
-              const resendEmailResult = await sendInvitationForRoute({
-                baseURL: new URL(request.url).origin,
-                db,
-                env: appContext.env,
-                invitation: refreshed,
-                inviter: {
-                  email: session.user.email,
-                  name: session.user.name,
-                },
-              })
-              if (resendEmailResult.isErr()) {
-                return Result.err(resendEmailResult.error)
-              }
-
-              return Result.ok(toInvitation(refreshed))
+                .set({ expiresAt: existing.expiresAt })
+                .where(
+                  and(
+                    eq(schema.invitation.id, existing.id),
+                    eq(schema.invitation.status, 'pending'),
+                    eq(schema.invitation.expiresAt, refreshedExpiry),
+                  ),
+                )
+              return Result.err(resendEmailResult.error)
             }
+
+            return Result.ok(toInvitation(refreshed))
           }
 
           const invitation = yield* Result.await(

--- a/apps/web/src/routes/api/workspaces/$id/members.ts
+++ b/apps/web/src/routes/api/workspaces/$id/members.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 import { createFileRoute } from '@tanstack/react-router'
 import { Result, TaggedError } from 'better-result'
 import { createLogger } from '@garden/observability/console'
@@ -40,7 +40,7 @@ type AuthInvitation = {
   email: string
   role?: string
   status: string
-  createdAt: Date
+  createdAt?: Date | null
   expiresAt: Date
 }
 
@@ -163,6 +163,57 @@ export const Route = createFileRoute('/api/workspaces/$id/members')({
             )
           }
           const body = bodyResult.value
+          const db = await appContext.db()
+
+          /**
+           * Resend path: refresh the existing pending row in place. Better
+           * Auth's own `resend` flag cannot be used here — its
+           * findPendingInvitation filters out expired invites (adapter.mjs),
+           * so resending an expired invite would silently create a duplicate
+           * row and orphan the original. Garden owns the mutation instead:
+           * same effect as Better Auth's resend (extends expiresAt by the
+           * default 48h window), but covering expired rows too.
+           */
+          if (body.resend) {
+            const [existing] = await db
+              .select()
+              .from(schema.invitation)
+              .where(
+                and(
+                  eq(schema.invitation.organizationId, params.id),
+                  sql`lower(${schema.invitation.email}) = lower(${body.email})`,
+                  eq(schema.invitation.status, 'pending'),
+                ),
+              )
+              .limit(1)
+
+            if (existing) {
+              // Mirrors Better Auth's invitationExpiresIn default (48h).
+              const refreshedExpiry = new Date(Date.now() + 48 * 3600 * 1000)
+              await db
+                .update(schema.invitation)
+                .set({ expiresAt: refreshedExpiry })
+                .where(eq(schema.invitation.id, existing.id))
+
+              const refreshed = { ...existing, expiresAt: refreshedExpiry }
+              const resendEmailResult = await sendInvitationForRoute({
+                baseURL: new URL(request.url).origin,
+                db,
+                env: appContext.env,
+                invitation: refreshed,
+                inviter: {
+                  email: session.user.email,
+                  name: session.user.name,
+                },
+              })
+              if (resendEmailResult.isErr()) {
+                return Result.err(resendEmailResult.error)
+              }
+
+              return Result.ok(toInvitation(refreshed))
+            }
+          }
+
           const invitation = yield* Result.await(
             Result.tryPromise({
               try: async () =>
@@ -196,6 +247,9 @@ export const Route = createFileRoute('/api/workspaces/$id/members')({
           })
 
           if (emailResult.isErr()) {
+            // Cancel only invites this request created. The resend path
+            // returned above before reaching here, so every invitation at
+            // this point is newly created.
             const cancelResult = await Result.tryPromise({
               try: async () => {
                 await auth.api.cancelInvitation({

--- a/apps/web/src/routes/forgot-password.tsx
+++ b/apps/web/src/routes/forgot-password.tsx
@@ -1,14 +1,21 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { RequestPasswordResetPage } from '@/features/auth'
+import { sanitizeRedirectTarget } from '@/lib/redirect'
 
 export const Route = createFileRoute('/forgot-password')({
   validateSearch: (search) => ({
     email: typeof search.email === 'string' ? search.email : undefined,
+    redirect:
+      typeof search.redirect === 'string'
+        ? sanitizeRedirectTarget(search.redirect)
+        : undefined,
   }),
   component: ForgotPasswordRoute,
 })
 
 function ForgotPasswordRoute() {
-  const { email } = Route.useSearch()
-  return <RequestPasswordResetPage initialEmail={email} />
+  const { email, redirect } = Route.useSearch()
+  return (
+    <RequestPasswordResetPage initialEmail={email} redirectTarget={redirect} />
+  )
 }

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -3,10 +3,10 @@ import { LoginPage } from '@/features/auth'
 import { sanitizeRedirectTarget } from '@/lib/redirect'
 import { getRouteSession } from '@/lib/server/route-session'
 import {
-  getSignupInvitationPreview,
   invitationIdFromRedirect,
   type SignupInvitationPreview,
-} from '@/lib/server/invitations'
+} from '@/lib/invitation-flow'
+import { getSignupInvitationPreview } from '@/lib/server/invitations'
 
 export const Route = createFileRoute('/login')({
   validateSearch: (search) => ({
@@ -58,6 +58,7 @@ function LoginRoute() {
       invitationWorkspaceName={
         invitationIsPending ? invitation.organizationName : undefined
       }
+      redirectTarget={search.redirect}
       onSuccess={() =>
         void navigate({ href: search.redirect ?? '/workspace', replace: true })
       }

--- a/apps/web/src/routes/reset-password.tsx
+++ b/apps/web/src/routes/reset-password.tsx
@@ -1,15 +1,26 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { ResetPasswordPage } from '@/features/auth'
+import { sanitizeRedirectTarget } from '@/lib/redirect'
 
 export const Route = createFileRoute('/reset-password')({
   validateSearch: (search) => ({
     token: typeof search.token === 'string' ? search.token : undefined,
     error: typeof search.error === 'string' ? search.error : undefined,
+    redirect:
+      typeof search.redirect === 'string'
+        ? sanitizeRedirectTarget(search.redirect)
+        : undefined,
   }),
   component: ResetPasswordRoute,
 })
 
 function ResetPasswordRoute() {
-  const { token, error } = Route.useSearch()
-  return <ResetPasswordPage token={token} invalidToken={Boolean(error)} />
+  const { token, error, redirect } = Route.useSearch()
+  return (
+    <ResetPasswordPage
+      token={token}
+      invalidToken={Boolean(error)}
+      redirectTarget={redirect}
+    />
+  )
 }

--- a/apps/web/src/routes/signup.tsx
+++ b/apps/web/src/routes/signup.tsx
@@ -3,10 +3,10 @@ import { LoginPage } from '@/features/auth'
 import { sanitizeRedirectTarget } from '@/lib/redirect'
 import { getRouteSession } from '@/lib/server/route-session'
 import {
-  getSignupInvitationPreview,
   invitationIdFromRedirect,
   type SignupInvitationPreview,
-} from '@/lib/server/invitations'
+} from '@/lib/invitation-flow'
+import { getSignupInvitationPreview } from '@/lib/server/invitations'
 
 export const Route = createFileRoute('/signup')({
   validateSearch: (search) => ({

--- a/apps/web/tsconfig.shared.json
+++ b/apps/web/tsconfig.shared.json
@@ -4,7 +4,8 @@
     "src/lib/api/document-artifact-contract.ts",
     "src/lib/api/garden-api-contract.ts",
     "src/lib/api/skills-contract.ts",
-    "src/lib/executor-contract.ts"
+    "src/lib/executor-contract.ts",
+    "src/lib/invitation-flow.ts"
   ],
   "compilerOptions": {
     "composite": true,

--- a/packages/core/src/types/api.ts
+++ b/packages/core/src/types/api.ts
@@ -71,6 +71,8 @@ export interface UpdateMeRequest {
 export interface CreateMemberRequest {
   email: string
   role?: MemberRole
+  /** Idempotent re-send of an existing pending (or expired) invitation. */
+  resend?: boolean
 }
 
 export interface UpdateMemberRequest {

--- a/packages/db/drizzle/0045_early_doctor_octopus.sql
+++ b/packages/db/drizzle/0045_early_doctor_octopus.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "auth_account" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();--> statement-breakpoint
+ALTER TABLE "auth_session" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();--> statement-breakpoint
+ALTER TABLE "auth_verification" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();

--- a/packages/db/drizzle/meta/0045_snapshot.json
+++ b/packages/db/drizzle/meta/0045_snapshot.json
@@ -1,0 +1,6104 @@
+{
+  "id": "c5cce709-5091-4cbb-b7b8-fcb4dbca3373",
+  "prevId": "3989b671-1344-48c6-a717-1508216603be",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_account": {
+      "name": "auth_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_account_user_id_user_id_fk": {
+          "name": "auth_account_user_id_user_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "auth_account_workspace_id_organization_id_fk": {
+          "name": "auth_account_workspace_id_organization_id_fk",
+          "tableFrom": "auth_account",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "auth_account_status_check": {
+          "name": "auth_account_status_check",
+          "value": "\"auth_account\".\"status\" is null or \"auth_account\".\"status\" in ('connected', 'degraded', 'disconnected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "auth_session_user_id_user_id_fk": {
+          "name": "auth_session_user_id_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_verification": {
+      "name": "auth_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "invitation_role_check": {
+          "name": "invitation_role_check",
+          "value": "\"invitation\".\"role\" in ('owner', 'admin', 'member')"
+        },
+        "invitation_status_check": {
+          "name": "invitation_status_check",
+          "value": "\"invitation\".\"status\" in ('pending', 'accepted', 'rejected', 'canceled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_organization_user_unique": {
+          "name": "member_organization_user_unique",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "member_role_check": {
+          "name": "member_role_check",
+          "value": "\"member\".\"role\" in ('owner', 'admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_prefix": {
+          "name": "issue_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ISS'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'free'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "organization_issue_prefix_format": {
+          "name": "organization_issue_prefix_format",
+          "value": "\"organization\".\"issue_prefix\" ~ '^[A-Z0-9]{2,8}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_title": {
+          "name": "role_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_config": {
+          "name": "runtime_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adapter_type": {
+          "name": "adapter_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workspace-agent'"
+        },
+        "reports_to": {
+          "name": "reports_to",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "host_name": {
+          "name": "host_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_timeout_sec": {
+          "name": "run_timeout_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 7200
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_workspace_owner_idx": {
+          "name": "agent_workspace_owner_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_workspace_reports_to_idx": {
+          "name": "agent_workspace_reports_to_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reports_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_default_idx": {
+          "name": "agent_default_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"agent\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_workspace_id_organization_id_fk": {
+          "name": "agent_workspace_id_organization_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_owner_user_id_user_id_fk": {
+          "name": "agent_owner_user_id_user_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_reports_to_agent_id_fk": {
+          "name": "agent_reports_to_agent_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "reports_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_status_check": {
+          "name": "agent_status_check",
+          "value": "\"agent\".\"status\" in ('active', 'pending_approval', 'archived')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.agent_proposal_request": {
+      "name": "agent_proposal_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending_agent_id": {
+          "name": "pending_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args_json": {
+          "name": "args_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_proposal_request_thread_idx": {
+          "name": "agent_proposal_request_thread_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_proposal_request_pending_idx": {
+          "name": "agent_proposal_request_pending_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requested_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_proposal_request_agent_id_agent_id_fk": {
+          "name": "agent_proposal_request_agent_id_agent_id_fk",
+          "tableFrom": "agent_proposal_request",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_proposal_request_pending_agent_id_agent_id_fk": {
+          "name": "agent_proposal_request_pending_agent_id_agent_id_fk",
+          "tableFrom": "agent_proposal_request",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "pending_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "agent_proposal_request_issue_id_issue_id_fk": {
+          "name": "agent_proposal_request_issue_id_issue_id_fk",
+          "tableFrom": "agent_proposal_request",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "agent_proposal_request_thread_id_chat_thread_id_fk": {
+          "name": "agent_proposal_request_thread_id_chat_thread_id_fk",
+          "tableFrom": "agent_proposal_request",
+          "tableTo": "chat_thread",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agent_proposal_request_status_check": {
+          "name": "agent_proposal_request_status_check",
+          "value": "\"agent_proposal_request\".\"status\" in ('pending', 'approved', 'denied')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.chat_thread": {
+      "name": "chat_thread",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "primary_issue_id": {
+          "name": "primary_issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_kind": {
+          "name": "runtime_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'chat'"
+        },
+        "runtime_key": {
+          "name": "runtime_key",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message": {
+          "name": "last_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "chat_thread_workspace_owner_idx": {
+          "name": "chat_thread_workspace_owner_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_thread_workspace_updated_idx": {
+          "name": "chat_thread_workspace_updated_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_thread_agent_idx": {
+          "name": "chat_thread_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_thread_primary_issue_idx": {
+          "name": "chat_thread_primary_issue_idx",
+          "columns": [
+            {
+              "expression": "primary_issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_thread_runtime_idx": {
+          "name": "chat_thread_runtime_idx",
+          "columns": [
+            {
+              "expression": "runtime_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "runtime_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_thread_workspace_id_organization_id_fk": {
+          "name": "chat_thread_workspace_id_organization_id_fk",
+          "tableFrom": "chat_thread",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chat_thread_owner_user_id_user_id_fk": {
+          "name": "chat_thread_owner_user_id_user_id_fk",
+          "tableFrom": "chat_thread",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chat_thread_agent_id_agent_id_fk": {
+          "name": "chat_thread_agent_id_agent_id_fk",
+          "tableFrom": "chat_thread",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chat_thread_primary_issue_id_issue_id_fk": {
+          "name": "chat_thread_primary_issue_id_issue_id_fk",
+          "tableFrom": "chat_thread",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "primary_issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chat_thread_runtime_kind_check": {
+          "name": "chat_thread_runtime_kind_check",
+          "value": "\"chat_thread\".\"runtime_kind\" in ('chat', 'issue_run')"
+        },
+        "chat_thread_title_nonempty": {
+          "name": "chat_thread_title_nonempty",
+          "value": "char_length(trim(\"chat_thread\".\"title\")) > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.document": {
+      "name": "document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structure_tree": {
+          "name": "structure_tree",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "current_version_id": {
+          "name": "current_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_workspace_owner_idx": {
+          "name": "document_workspace_owner_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_thread_idx": {
+          "name": "document_thread_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_current_version_idx": {
+          "name": "document_current_version_idx",
+          "columns": [
+            {
+              "expression": "current_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_workspace_id_organization_id_fk": {
+          "name": "document_workspace_id_organization_id_fk",
+          "tableFrom": "document",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "document_owner_user_id_user_id_fk": {
+          "name": "document_owner_user_id_user_id_fk",
+          "tableFrom": "document",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "document_thread_id_chat_thread_id_fk": {
+          "name": "document_thread_id_chat_thread_id_fk",
+          "tableFrom": "document",
+          "tableTo": "chat_thread",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "document_file_type_check": {
+          "name": "document_file_type_check",
+          "value": "\"document\".\"file_type\" in ('pdf', 'doc', 'docx', 'txt', 'md', 'json', 'csv', 'unknown')"
+        },
+        "document_status_check": {
+          "name": "document_status_check",
+          "value": "\"document\".\"status\" in ('processing', 'ready', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.document_version": {
+      "name": "document_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pdf_storage_path": {
+          "name": "pdf_storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_version_document_idx": {
+          "name": "document_version_document_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_version_document_number_idx": {
+          "name": "document_version_document_number_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "document_version_document_id_document_id_fk": {
+          "name": "document_version_document_id_document_id_fk",
+          "tableFrom": "document_version",
+          "tableTo": "document",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "document_version_source_check": {
+          "name": "document_version_source_check",
+          "value": "\"document_version\".\"source\" in ('upload', 'user_upload', 'generated')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.inbox_dismissal": {
+      "name": "inbox_dismissal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_key": {
+          "name": "item_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inbox_dismissal_workspace_user_item_unique": {
+          "name": "inbox_dismissal_workspace_user_item_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inbox_dismissal_user_idx": {
+          "name": "inbox_dismissal_user_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbox_dismissal_workspace_id_organization_id_fk": {
+          "name": "inbox_dismissal_workspace_id_organization_id_fk",
+          "tableFrom": "inbox_dismissal",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inbox_dismissal_user_id_user_id_fk": {
+          "name": "inbox_dismissal_user_id_user_id_fk",
+          "tableFrom": "inbox_dismissal",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.inbox_item": {
+      "name": "inbox_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_type": {
+          "name": "recipient_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_id": {
+          "name": "recipient_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_key": {
+          "name": "item_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_status": {
+          "name": "issue_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "activity_at": {
+          "name": "activity_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "inbox_item_workspace_recipient_key_unique": {
+          "name": "inbox_item_workspace_recipient_key_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inbox_item_recipient_idx": {
+          "name": "inbox_item_recipient_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recipient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "archived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "inbox_item_issue_idx": {
+          "name": "inbox_item_issue_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "inbox_item_workspace_id_organization_id_fk": {
+          "name": "inbox_item_workspace_id_organization_id_fk",
+          "tableFrom": "inbox_item",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inbox_item_recipient_id_user_id_fk": {
+          "name": "inbox_item_recipient_id_user_id_fk",
+          "tableFrom": "inbox_item",
+          "tableTo": "user",
+          "columnsFrom": [
+            "recipient_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inbox_item_issue_id_issue_id_fk": {
+          "name": "inbox_item_issue_id_issue_id_fk",
+          "tableFrom": "inbox_item",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "inbox_item_recipient_type_check": {
+          "name": "inbox_item_recipient_type_check",
+          "value": "\"inbox_item\".\"recipient_type\" in ('member', 'agent')"
+        },
+        "inbox_item_actor_type_check": {
+          "name": "inbox_item_actor_type_check",
+          "value": "\"inbox_item\".\"actor_type\" is null or \"inbox_item\".\"actor_type\" in ('member', 'agent')"
+        },
+        "inbox_item_severity_check": {
+          "name": "inbox_item_severity_check",
+          "value": "\"inbox_item\".\"severity\" in ('action_required', 'attention', 'info')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue": {
+      "name": "issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'todo'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'medium'"
+        },
+        "assignee_type": {
+          "name": "assignee_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_id": {
+          "name": "assignee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_run_id": {
+          "name": "active_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_summary": {
+          "name": "source_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions_override": {
+          "name": "permissions_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "labels": {
+          "name": "labels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_workspace_number_unique": {
+          "name": "issue_workspace_number_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_workspace_status_idx": {
+          "name": "issue_workspace_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_workspace_active_run_idx": {
+          "name": "issue_workspace_active_run_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_workspace_position_idx": {
+          "name": "issue_workspace_position_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_workspace_assignee_idx": {
+          "name": "issue_workspace_assignee_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignee_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "assignee_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_workspace_id_organization_id_fk": {
+          "name": "issue_workspace_id_organization_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_active_run_id_issue_run_id_fk": {
+          "name": "issue_active_run_id_issue_run_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "issue_run",
+          "columnsFrom": [
+            "active_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_parent_id_issue_id_fk": {
+          "name": "issue_parent_id_issue_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_created_by_user_id_fk": {
+          "name": "issue_created_by_user_id_fk",
+          "tableFrom": "issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_status_check": {
+          "name": "issue_status_check",
+          "value": "\"issue\".\"status\" in ('todo', 'in_progress', 'in_review', 'done', 'blocked', 'cancelled')"
+        },
+        "issue_priority_check": {
+          "name": "issue_priority_check",
+          "value": "\"issue\".\"priority\" in ('urgent', 'high', 'medium', 'low', 'none')"
+        },
+        "issue_assignee_type_check": {
+          "name": "issue_assignee_type_check",
+          "value": "\"issue\".\"assignee_type\" is null or \"issue\".\"assignee_type\" in ('user', 'agent')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_attachment": {
+      "name": "issue_attachment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploader_type": {
+          "name": "uploader_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploader_id": {
+          "name": "uploader_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_attachment_workspace_idx": {
+          "name": "issue_attachment_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_attachment_issue_idx": {
+          "name": "issue_attachment_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_attachment_comment_idx": {
+          "name": "issue_attachment_comment_idx",
+          "columns": [
+            {
+              "expression": "comment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_attachment_workspace_id_organization_id_fk": {
+          "name": "issue_attachment_workspace_id_organization_id_fk",
+          "tableFrom": "issue_attachment",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_attachment_issue_id_issue_id_fk": {
+          "name": "issue_attachment_issue_id_issue_id_fk",
+          "tableFrom": "issue_attachment",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_attachment_comment_id_issue_comment_id_fk": {
+          "name": "issue_attachment_comment_id_issue_comment_id_fk",
+          "tableFrom": "issue_attachment",
+          "tableTo": "issue_comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_attachment_uploader_type_check": {
+          "name": "issue_attachment_uploader_type_check",
+          "value": "\"issue_attachment\".\"uploader_type\" in ('member', 'agent')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_comment": {
+      "name": "issue_comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_type": {
+          "name": "author_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentions": {
+          "name": "mentions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_comment_mentions_gin": {
+          "name": "issue_comment_mentions_gin",
+          "columns": [
+            {
+              "expression": "mentions",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_comment_issue_id_issue_id_fk": {
+          "name": "issue_comment_issue_id_issue_id_fk",
+          "tableFrom": "issue_comment",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_comment_author_type_check": {
+          "name": "issue_comment_author_type_check",
+          "value": "\"issue_comment\".\"author_type\" in ('user', 'agent')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_run": {
+      "name": "issue_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_name": {
+          "name": "host_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_ref": {
+          "name": "trigger_ref",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_run_id": {
+          "name": "parent_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_snapshot": {
+          "name": "context_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_json": {
+          "name": "usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_run_issue_idx": {
+          "name": "issue_run_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_run_agent_active_idx": {
+          "name": "issue_run_agent_active_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue_run\".\"status\" in ('queued', 'running', 'waiting_for_input', 'waiting_for_approval')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_run_silent_idx": {
+          "name": "issue_run_silent_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue_run\".\"status\" = 'running'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_run_workflow_idx": {
+          "name": "issue_run_workflow_idx",
+          "columns": [
+            {
+              "expression": "workflow_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue_run\".\"workflow_instance_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_run_parent_idx": {
+          "name": "issue_run_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"issue_run\".\"parent_run_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_run_workspace_id_organization_id_fk": {
+          "name": "issue_run_workspace_id_organization_id_fk",
+          "tableFrom": "issue_run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_run_issue_id_issue_id_fk": {
+          "name": "issue_run_issue_id_issue_id_fk",
+          "tableFrom": "issue_run",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_run_agent_id_agent_id_fk": {
+          "name": "issue_run_agent_id_agent_id_fk",
+          "tableFrom": "issue_run",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_run_parent_run_id_issue_run_id_fk": {
+          "name": "issue_run_parent_run_id_issue_run_id_fk",
+          "tableFrom": "issue_run",
+          "tableTo": "issue_run",
+          "columnsFrom": [
+            "parent_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_run_status_check": {
+          "name": "issue_run_status_check",
+          "value": "\"issue_run\".\"status\" in ('queued', 'running', 'waiting_for_input', 'waiting_for_approval', 'succeeded', 'failed', 'cancelled', 'blocked')"
+        },
+        "issue_run_trigger_source_check": {
+          "name": "issue_run_trigger_source_check",
+          "value": "\"issue_run\".\"trigger_source\" is null or \"issue_run\".\"trigger_source\" in ('schedule', 'manual', 'webhook', 'api', 'chat', 'sub_agent', 'comment', 'mention', 'assignment', 'connector_event', 'reconciler_retry', 'hire_approval')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_run_event": {
+      "name": "issue_run_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stream": {
+          "name": "stream",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_run_event_seq_unique": {
+          "name": "issue_run_event_seq_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_run_event_issue_idx": {
+          "name": "issue_run_event_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_run_event_workspace_id_organization_id_fk": {
+          "name": "issue_run_event_workspace_id_organization_id_fk",
+          "tableFrom": "issue_run_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_run_event_issue_id_issue_id_fk": {
+          "name": "issue_run_event_issue_id_issue_id_fk",
+          "tableFrom": "issue_run_event",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_run_event_run_id_issue_run_id_fk": {
+          "name": "issue_run_event_run_id_issue_run_id_fk",
+          "tableFrom": "issue_run_event",
+          "tableTo": "issue_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_run_event_stream_check": {
+          "name": "issue_run_event_stream_check",
+          "value": "\"issue_run_event\".\"stream\" in ('system', 'agent', 'tool', 'connector')"
+        },
+        "issue_run_event_level_check": {
+          "name": "issue_run_event_level_check",
+          "value": "\"issue_run_event\".\"level\" in ('info', 'warn', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_source_binding": {
+      "name": "issue_source_binding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_ref": {
+          "name": "display_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title_snapshot": {
+          "name": "title_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_source_binding_external_unique": {
+          "name": "issue_source_binding_external_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_source_binding_issue_idx": {
+          "name": "issue_source_binding_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_source_binding_workspace_id_organization_id_fk": {
+          "name": "issue_source_binding_workspace_id_organization_id_fk",
+          "tableFrom": "issue_source_binding",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_source_binding_issue_id_issue_id_fk": {
+          "name": "issue_source_binding_issue_id_issue_id_fk",
+          "tableFrom": "issue_source_binding",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_source_binding_connector_check": {
+          "name": "issue_source_binding_connector_check",
+          "value": "\"issue_source_binding\".\"connector_id\" in ('github', 'slack', 'gmail', 'google_drive', 'manual', 'agent')"
+        },
+        "issue_source_binding_kind_check": {
+          "name": "issue_source_binding_kind_check",
+          "value": "\"issue_source_binding\".\"source_kind\" in ('issue', 'pull_request', 'message', 'thread', 'email_thread', 'file', 'search_result')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_subscriber": {
+      "name": "issue_subscriber",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_type": {
+          "name": "user_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_subscriber_issue_user_unique": {
+          "name": "issue_subscriber_issue_user_unique",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_subscriber_issue_idx": {
+          "name": "issue_subscriber_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_subscriber_workspace_id_organization_id_fk": {
+          "name": "issue_subscriber_workspace_id_organization_id_fk",
+          "tableFrom": "issue_subscriber",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_subscriber_issue_id_issue_id_fk": {
+          "name": "issue_subscriber_issue_id_issue_id_fk",
+          "tableFrom": "issue_subscriber",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_subscriber_user_type_check": {
+          "name": "issue_subscriber_user_type_check",
+          "value": "\"issue_subscriber\".\"user_type\" in ('member', 'agent')"
+        },
+        "issue_subscriber_reason_check": {
+          "name": "issue_subscriber_reason_check",
+          "value": "\"issue_subscriber\".\"reason\" in ('creator', 'assignee', 'commenter', 'mentioned', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.issue_work_product": {
+      "name": "issue_work_product",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "review_state": {
+          "name": "review_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_external_id": {
+          "name": "applied_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applied_external_url": {
+          "name": "applied_external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "issue_work_product_primary_unique": {
+          "name": "issue_work_product_primary_unique",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"issue_work_product\".\"is_primary\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "issue_work_product_issue_idx": {
+          "name": "issue_work_product_issue_idx",
+          "columns": [
+            {
+              "expression": "issue_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "issue_work_product_workspace_id_organization_id_fk": {
+          "name": "issue_work_product_workspace_id_organization_id_fk",
+          "tableFrom": "issue_work_product",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "issue_work_product_issue_id_issue_id_fk": {
+          "name": "issue_work_product_issue_id_issue_id_fk",
+          "tableFrom": "issue_work_product",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "issue_work_product_run_id_issue_run_id_fk": {
+          "name": "issue_work_product_run_id_issue_run_id_fk",
+          "tableFrom": "issue_work_product",
+          "tableTo": "issue_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "issue_work_product_agent_id_agent_id_fk": {
+          "name": "issue_work_product_agent_id_agent_id_fk",
+          "tableFrom": "issue_work_product",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "issue_work_product_type_check": {
+          "name": "issue_work_product_type_check",
+          "value": "\"issue_work_product\".\"type\" in ('brief', 'plan', 'connector_reply', 'pull_request', 'report', 'checklist')"
+        },
+        "issue_work_product_status_check": {
+          "name": "issue_work_product_status_check",
+          "value": "\"issue_work_product\".\"status\" in ('draft', 'review', 'approved', 'applied', 'superseded')"
+        },
+        "issue_work_product_review_check": {
+          "name": "issue_work_product_review_check",
+          "value": "\"issue_work_product\".\"review_state\" in ('pending', 'approved', 'changes_requested')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.automation": {
+      "name": "automation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee_agent_id": {
+          "name": "assignee_agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "concurrency_policy": {
+          "name": "concurrency_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'skip'"
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_sources": {
+          "name": "context_sources",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_config": {
+          "name": "output_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_config": {
+          "name": "execution_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_config": {
+          "name": "notification_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduling_config": {
+          "name": "scheduling_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_source": {
+          "name": "template_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_count": {
+          "name": "run_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_count": {
+          "name": "success_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_count": {
+          "name": "failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skip_count": {
+          "name": "skip_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "avg_duration_ms": {
+          "name": "avg_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "automation_workspace_status_idx": {
+          "name": "automation_workspace_status_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_next_run_idx": {
+          "name": "automation_next_run_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_category_idx": {
+          "name": "automation_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_tags_gin": {
+          "name": "automation_tags_gin",
+          "columns": [
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_workspace_id_organization_id_fk": {
+          "name": "automation_workspace_id_organization_id_fk",
+          "tableFrom": "automation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "automation_assignee_agent_id_agent_id_fk": {
+          "name": "automation_assignee_agent_id_agent_id_fk",
+          "tableFrom": "automation",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "assignee_agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "automation_created_by_user_id_fk": {
+          "name": "automation_created_by_user_id_fk",
+          "tableFrom": "automation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "automation_updated_by_user_id_fk": {
+          "name": "automation_updated_by_user_id_fk",
+          "tableFrom": "automation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "updated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "automation_status_check": {
+          "name": "automation_status_check",
+          "value": "\"automation\".\"status\" in ('active', 'paused', 'archived')"
+        },
+        "automation_priority_check": {
+          "name": "automation_priority_check",
+          "value": "\"automation\".\"priority\" in ('urgent', 'high', 'medium', 'low', 'none')"
+        },
+        "automation_concurrency_policy_check": {
+          "name": "automation_concurrency_policy_check",
+          "value": "\"automation\".\"concurrency_policy\" in ('skip', 'queue', 'replace')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.automation_run": {
+      "name": "automation_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_name": {
+          "name": "host_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workflow_instance_id": {
+          "name": "workflow_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_snapshot": {
+          "name": "context_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_json": {
+          "name": "usage_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggered_at": {
+          "name": "triggered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger_payload": {
+          "name": "trigger_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_run_workspace_idx": {
+          "name": "automation_run_workspace_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_run_automation_idx": {
+          "name": "automation_run_automation_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_run_agent_active_idx": {
+          "name": "automation_run_agent_active_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"automation_run\".\"status\" in ('queued', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_run_workflow_idx": {
+          "name": "automation_run_workflow_idx",
+          "columns": [
+            {
+              "expression": "workflow_instance_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"automation_run\".\"workflow_instance_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_run_workspace_id_organization_id_fk": {
+          "name": "automation_run_workspace_id_organization_id_fk",
+          "tableFrom": "automation_run",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "automation_run_automation_id_automation_id_fk": {
+          "name": "automation_run_automation_id_automation_id_fk",
+          "tableFrom": "automation_run",
+          "tableTo": "automation",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "automation_run_trigger_id_automation_trigger_id_fk": {
+          "name": "automation_run_trigger_id_automation_trigger_id_fk",
+          "tableFrom": "automation_run",
+          "tableTo": "automation_trigger",
+          "columnsFrom": [
+            "trigger_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "automation_run_agent_id_agent_id_fk": {
+          "name": "automation_run_agent_id_agent_id_fk",
+          "tableFrom": "automation_run",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "automation_run_source_check": {
+          "name": "automation_run_source_check",
+          "value": "\"automation_run\".\"source\" in ('schedule', 'manual', 'webhook', 'api')"
+        },
+        "automation_run_status_check": {
+          "name": "automation_run_status_check",
+          "value": "\"automation_run\".\"status\" in ('pending', 'queued', 'running', 'completed', 'failed', 'cancelled', 'skipped')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.automation_trigger": {
+      "name": "automation_trigger",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "automation_id": {
+          "name": "automation_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_token_hash": {
+          "name": "webhook_token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "automation_trigger_automation_idx": {
+          "name": "automation_trigger_automation_idx",
+          "columns": [
+            {
+              "expression": "automation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_trigger_enabled_idx": {
+          "name": "automation_trigger_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"automation_trigger\".\"kind\" = 'schedule' and \"automation_trigger\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "automation_trigger_webhook_token_unique": {
+          "name": "automation_trigger_webhook_token_unique",
+          "columns": [
+            {
+              "expression": "webhook_token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"automation_trigger\".\"webhook_token_hash\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "automation_trigger_automation_id_automation_id_fk": {
+          "name": "automation_trigger_automation_id_automation_id_fk",
+          "tableFrom": "automation_trigger",
+          "tableTo": "automation",
+          "columnsFrom": [
+            "automation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "automation_trigger_kind_check": {
+          "name": "automation_trigger_kind_check",
+          "value": "\"automation_trigger\".\"kind\" in ('schedule', 'webhook', 'api')"
+        },
+        "automation_trigger_schedule_fields_check": {
+          "name": "automation_trigger_schedule_fields_check",
+          "value": "(\"automation_trigger\".\"kind\" <> 'schedule') or (\"automation_trigger\".\"cron_expression\" is not null and \"automation_trigger\".\"timezone\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.skill": {
+      "name": "skill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frontmatter": {
+          "name": "frontmatter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_hash": {
+          "name": "bundle_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "skill_workspace_slug_unique": {
+          "name": "skill_workspace_slug_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skill_workspace_id_organization_id_fk": {
+          "name": "skill_workspace_id_organization_id_fk",
+          "tableFrom": "skill",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skill_author_id_user_id_fk": {
+          "name": "skill_author_id_user_id_fk",
+          "tableFrom": "skill",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill_assignment": {
+      "name": "skill_assignment",
+      "schema": "",
+      "columns": {
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_kind": {
+          "name": "target_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "skill_assignment_target_idx": {
+          "name": "skill_assignment_target_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skill_assignment_skill_idx": {
+          "name": "skill_assignment_skill_idx",
+          "columns": [
+            {
+              "expression": "skill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "skill_assignment_workspace_id_organization_id_fk": {
+          "name": "skill_assignment_workspace_id_organization_id_fk",
+          "tableFrom": "skill_assignment",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skill_assignment_skill_id_skill_id_fk": {
+          "name": "skill_assignment_skill_id_skill_id_fk",
+          "tableFrom": "skill_assignment",
+          "tableTo": "skill",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "skill_assignment_workspace_id_target_kind_target_id_skill_id_pk": {
+          "name": "skill_assignment_workspace_id_target_kind_target_id_skill_id_pk",
+          "columns": [
+            "workspace_id",
+            "target_kind",
+            "target_id",
+            "skill_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "skill_assignment_target_kind_check": {
+          "name": "skill_assignment_target_kind_check",
+          "value": "\"skill_assignment\".\"target_kind\" in ('workspace_chat', 'agent')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.skill_file": {
+      "name": "skill_file",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skill_file_skill_id_skill_id_fk": {
+          "name": "skill_file_skill_id_skill_id_fk",
+          "tableFrom": "skill_file",
+          "tableTo": "skill",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill_version": {
+      "name": "skill_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "frontmatter": {
+          "name": "frontmatter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "skill_version_skill_id_skill_id_fk": {
+          "name": "skill_version_skill_id_skill_id_fk",
+          "tableFrom": "skill_version",
+          "tableTo": "skill",
+          "columnsFrom": [
+            "skill_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "skill_version_author_id_user_id_fk": {
+          "name": "skill_version_author_id_user_id_fk",
+          "tableFrom": "skill_version",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.capability": {
+      "name": "capability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connector_type": {
+          "name": "connector_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_hash": {
+          "name": "schema_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "required_scopes": {
+          "name": "required_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "risk_class": {
+          "name": "risk_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "capability_connector_type_name_unique": {
+          "name": "capability_connector_type_name_unique",
+          "columns": [
+            {
+              "expression": "connector_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "capability_risk_class_check": {
+          "name": "capability_risk_class_check",
+          "value": "\"capability\".\"risk_class\" in ('read', 'write', 'send_external', 'destructive')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.permission_grant": {
+      "name": "permission_grant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trust_level": {
+          "name": "trust_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ask'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "permission_grant_agent_capability_unique": {
+          "name": "permission_grant_agent_capability_unique",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "capability_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permission_grant_agent_id_agent_id_fk": {
+          "name": "permission_grant_agent_id_agent_id_fk",
+          "tableFrom": "permission_grant",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "permission_grant_capability_id_capability_id_fk": {
+          "name": "permission_grant_capability_id_capability_id_fk",
+          "tableFrom": "permission_grant",
+          "tableTo": "capability",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "permission_grant_granted_by_user_id_fk": {
+          "name": "permission_grant_granted_by_user_id_fk",
+          "tableFrom": "permission_grant",
+          "tableTo": "user",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "permission_grant_trust_level_check": {
+          "name": "permission_grant_trust_level_check",
+          "value": "\"permission_grant\".\"trust_level\" in ('auto', 'allow', 'ask')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.permission_request": {
+      "name": "permission_request",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connector_write'"
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue_id": {
+          "name": "issue_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "args_json": {
+          "name": "args_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "permission_request_thread_idx": {
+          "name": "permission_request_thread_idx",
+          "columns": [
+            {
+              "expression": "thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permission_request_agent_id_agent_id_fk": {
+          "name": "permission_request_agent_id_agent_id_fk",
+          "tableFrom": "permission_request",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "permission_request_capability_id_capability_id_fk": {
+          "name": "permission_request_capability_id_capability_id_fk",
+          "tableFrom": "permission_request",
+          "tableTo": "capability",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "permission_request_issue_id_issue_id_fk": {
+          "name": "permission_request_issue_id_issue_id_fk",
+          "tableFrom": "permission_request",
+          "tableTo": "issue",
+          "columnsFrom": [
+            "issue_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "permission_request_run_id_issue_run_id_fk": {
+          "name": "permission_request_run_id_issue_run_id_fk",
+          "tableFrom": "permission_request",
+          "tableTo": "issue_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "permission_request_thread_id_chat_thread_id_fk": {
+          "name": "permission_request_thread_id_chat_thread_id_fk",
+          "tableFrom": "permission_request",
+          "tableTo": "chat_thread",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "permission_request_status_check": {
+          "name": "permission_request_status_check",
+          "value": "\"permission_request\".\"status\" in ('pending', 'approved', 'denied')"
+        },
+        "permission_request_kind_check": {
+          "name": "permission_request_kind_check",
+          "value": "\"permission_request\".\"kind\" in ('connector_write', 'agent_proposal')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.activity_event": {
+      "name": "activity_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_event_workspace_created_at_idx": {
+          "name": "activity_event_workspace_created_at_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_event_workspace_id_organization_id_fk": {
+          "name": "activity_event_workspace_id_organization_id_fk",
+          "tableFrom": "activity_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connector_callback_event": {
+      "name": "connector_callback_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connector_id": {
+          "name": "connector_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flow_id": {
+          "name": "flow_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stage": {
+          "name": "stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'callback'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connector_callback_event_workspace_created_at_idx": {
+          "name": "connector_callback_event_workspace_created_at_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connector_callback_event_flow_idx": {
+          "name": "connector_callback_event_flow_idx",
+          "columns": [
+            {
+              "expression": "flow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connector_callback_event_connector_created_at_idx": {
+          "name": "connector_callback_event_connector_created_at_idx",
+          "columns": [
+            {
+              "expression": "connector_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connector_callback_event_workspace_id_organization_id_fk": {
+          "name": "connector_callback_event_workspace_id_organization_id_fk",
+          "tableFrom": "connector_callback_event",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connector_callback_event_user_id_user_id_fk": {
+          "name": "connector_callback_event_user_id_user_id_fk",
+          "tableFrom": "connector_callback_event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "connector_callback_event_source_check": {
+          "name": "connector_callback_event_source_check",
+          "value": "\"connector_callback_event\".\"source\" in ('oauth', 'github_app')"
+        },
+        "connector_callback_event_status_check": {
+          "name": "connector_callback_event_status_check",
+          "value": "\"connector_callback_event\".\"status\" in ('success', 'degraded', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invocation_log": {
+      "name": "invocation_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_summary": {
+          "name": "output_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "invocation_log_agent_created_at_idx": {
+          "name": "invocation_log_agent_created_at_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invocation_log_capability_created_at_idx": {
+          "name": "invocation_log_capability_created_at_idx",
+          "columns": [
+            {
+              "expression": "capability_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invocation_log_agent_id_agent_id_fk": {
+          "name": "invocation_log_agent_id_agent_id_fk",
+          "tableFrom": "invocation_log",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invocation_log_capability_id_capability_id_fk": {
+          "name": "invocation_log_capability_id_capability_id_fk",
+          "tableFrom": "invocation_log",
+          "tableTo": "capability",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool_call_audit": {
+      "name": "tool_call_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capability_id": {
+          "name": "capability_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "args_hash": {
+          "name": "args_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "result_status": {
+          "name": "result_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ts": {
+          "name": "ts",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tool_call_audit_workspace_ts_idx": {
+          "name": "tool_call_audit_workspace_ts_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tool_call_audit_capability_ts_idx": {
+          "name": "tool_call_audit_capability_ts_idx",
+          "columns": [
+            {
+              "expression": "capability_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tool_call_audit_workspace_id_organization_id_fk": {
+          "name": "tool_call_audit_workspace_id_organization_id_fk",
+          "tableFrom": "tool_call_audit",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tool_call_audit_agent_id_agent_id_fk": {
+          "name": "tool_call_audit_agent_id_agent_id_fk",
+          "tableFrom": "tool_call_audit",
+          "tableTo": "agent",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tool_call_audit_capability_id_capability_id_fk": {
+          "name": "tool_call_audit_capability_id_capability_id_fk",
+          "tableFrom": "tool_call_audit",
+          "tableTo": "capability",
+          "columnsFrom": [
+            "capability_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tool_call_audit_result_status_check": {
+          "name": "tool_call_audit_result_status_check",
+          "value": "\"tool_call_audit\".\"result_status\" in ('success', 'error', 'denied', 'timeout')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_app_installation": {
+      "name": "github_app_installation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repository_selection": {
+          "name": "repository_selection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'selected'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "connected_by": {
+          "name": "connected_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "github_app_installation_workspace_unique": {
+          "name": "github_app_installation_workspace_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_app_installation_workspace_id_organization_id_fk": {
+          "name": "github_app_installation_workspace_id_organization_id_fk",
+          "tableFrom": "github_app_installation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installation_connected_by_user_id_fk": {
+          "name": "github_app_installation_connected_by_user_id_fk",
+          "tableFrom": "github_app_installation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "connected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "github_app_installation_status_check": {
+          "name": "github_app_installation_status_check",
+          "value": "\"github_app_installation\".\"status\" in ('connected', 'degraded', 'disconnected')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.discord_bot_installation": {
+      "name": "discord_bot_installation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_name": {
+          "name": "guild_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_icon": {
+          "name": "guild_icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "connected_by": {
+          "name": "connected_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discord_bot_installation_workspace_unique": {
+          "name": "discord_bot_installation_workspace_unique",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_bot_installation_workspace_id_organization_id_fk": {
+          "name": "discord_bot_installation_workspace_id_organization_id_fk",
+          "tableFrom": "discord_bot_installation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "discord_bot_installation_connected_by_user_id_fk": {
+          "name": "discord_bot_installation_connected_by_user_id_fk",
+          "tableFrom": "discord_bot_installation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "connected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "discord_bot_installation_status_check": {
+          "name": "discord_bot_installation_status_check",
+          "value": "\"discord_bot_installation\".\"status\" in ('connected', 'degraded', 'disconnected')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1786168242609,
       "tag": "0044_mute_frightful_four",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1788477954030,
+      "tag": "0045_early_doctor_octopus",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -1,66 +1,72 @@
-import { sql } from 'drizzle-orm'
-import { check, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core'
-import { user } from './users.js'
-import { organization } from './workspaces.js'
+import { sql } from "drizzle-orm";
+import { check, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { user } from "./users.js";
+import { organization } from "./workspaces.js";
 
-export const session = pgTable('auth_session', {
-  id: uuid('id').primaryKey(),
-  expiresAt: timestamp('expires_at', { mode: 'date' }).notNull(),
-  token: text('token').notNull(),
-  createdAt: timestamp('created_at', { mode: 'date' }).notNull(),
-  updatedAt: timestamp('updated_at', { mode: 'date' }).notNull(),
-  ipAddress: text('ip_address'),
-  userAgent: text('user_agent'),
-  activeOrganizationId: uuid('active_organization_id'),
-  userId: uuid('user_id')
+export const session = pgTable("auth_session", {
+  id: uuid("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()`),
+  expiresAt: timestamp("expires_at", { mode: "date" }).notNull(),
+  token: text("token").notNull(),
+  createdAt: timestamp("created_at", { mode: "date" }).notNull(),
+  updatedAt: timestamp("updated_at", { mode: "date" }).notNull(),
+  ipAddress: text("ip_address"),
+  userAgent: text("user_agent"),
+  activeOrganizationId: uuid("active_organization_id"),
+  userId: uuid("user_id")
     .notNull()
-    .references(() => user.id, { onDelete: 'cascade' }),
-})
+    .references(() => user.id, { onDelete: "cascade" }),
+});
 
 export const account = pgTable(
-  'auth_account',
+  "auth_account",
   {
-    id: uuid('id').primaryKey(),
-    accountId: text('account_id').notNull(),
-    providerId: text('provider_id').notNull(),
-    userId: uuid('user_id')
+    id: uuid("id")
+      .primaryKey()
+      .default(sql`gen_random_uuid()`),
+    accountId: text("account_id").notNull(),
+    providerId: text("provider_id").notNull(),
+    userId: uuid("user_id")
       .notNull()
-      .references(() => user.id, { onDelete: 'cascade' }),
-    accessToken: text('access_token'),
-    refreshToken: text('refresh_token'),
-    idToken: text('id_token'),
-    accessTokenExpiresAt: timestamp('access_token_expires_at', {
-      mode: 'date',
+      .references(() => user.id, { onDelete: "cascade" }),
+    accessToken: text("access_token"),
+    refreshToken: text("refresh_token"),
+    idToken: text("id_token"),
+    accessTokenExpiresAt: timestamp("access_token_expires_at", {
+      mode: "date",
     }),
-    refreshTokenExpiresAt: timestamp('refresh_token_expires_at', {
-      mode: 'date',
+    refreshTokenExpiresAt: timestamp("refresh_token_expires_at", {
+      mode: "date",
     }),
-    scope: text('scope'),
-    workspaceId: uuid('workspace_id').references(() => organization.id, {
-      onDelete: 'cascade',
+    scope: text("scope"),
+    workspaceId: uuid("workspace_id").references(() => organization.id, {
+      onDelete: "cascade",
     }),
-    status: text('status'),
-    scopes: text('scopes')
+    status: text("status"),
+    scopes: text("scopes")
       .array()
       .default(sql`'{}'::text[]`),
-    connectorType: text('connector_type'),
-    password: text('password'),
-    createdAt: timestamp('created_at', { mode: 'date' }).notNull(),
-    updatedAt: timestamp('updated_at', { mode: 'date' }).notNull(),
+    connectorType: text("connector_type"),
+    password: text("password"),
+    createdAt: timestamp("created_at", { mode: "date" }).notNull(),
+    updatedAt: timestamp("updated_at", { mode: "date" }).notNull(),
   },
   (table) => [
     check(
-      'auth_account_status_check',
+      "auth_account_status_check",
       sql`${table.status} is null or ${table.status} in ('connected', 'degraded', 'disconnected')`,
     ),
   ],
-)
+);
 
-export const verification = pgTable('auth_verification', {
-  id: uuid('id').primaryKey(),
-  identifier: text('identifier').notNull(),
-  value: text('value').notNull(),
-  expiresAt: timestamp('expires_at', { mode: 'date' }).notNull(),
-  createdAt: timestamp('created_at', { mode: 'date' }),
-  updatedAt: timestamp('updated_at', { mode: 'date' }),
-})
+export const verification = pgTable("auth_verification", {
+  id: uuid("id")
+    .primaryKey()
+    .default(sql`gen_random_uuid()`),
+  identifier: text("identifier").notNull(),
+  value: text("value").notNull(),
+  expiresAt: timestamp("expires_at", { mode: "date" }).notNull(),
+  createdAt: timestamp("created_at", { mode: "date" }),
+  updatedAt: timestamp("updated_at", { mode: "date" }),
+});


### PR DESCRIPTION
# Summary

Workspace invites were undeliverable in practice: the email sent fine, but every acceptance failed with "We could not open this invite".

Root cause: Better Auth 1.6.26 gates `acceptInvitation` behind `user.emailVerified` whenever  advanced.database.generateId` is a custom function (`shouldRequireVerifiedEmailForInvitationIdAction`, crud-invites.mjs) — a heuristic against guessable invitation ids. Garden set `() => crypto.randomUUID()` and has no email-verification flow, so every email/password invitee was rejected with FORBIDDEN.

Fix: switch to the supported `generateId: "uuid"`. Better Auth then treats ids as opaque and defers generation to Postgres; migration 0045 adds the three `gen_random_uuid()` defaults that mode requires. The rest of the change hardens the invite lifecycle around that fix: idempotent re-acceptance, race-safe recovery, session-cookie refresh, per-reason error copy, and admin resend.

User impact: invite links work for all sign-in methods; reopening a used link reopens the workspace; wrong-account and expired/canceled states explain themselves; admins can resend (including expired invites) without duplicates.

## Scope

- In scope: invite acceptance path (auth config, service, route), invite auth UX (locked mode, sign-out-and-continue, password-reset redirect continuity),   members settings (expired state, resend), migration 0045, integration/UI/e2e
  test coverage.
- Out of scope: an email-verification feature, the staging deploy/migration run, changes to Resend delivery itself.

## Invariants

- [x] Canonical identity is defined where records/events are involved. (invitation = opaque uuid PK; membership = (organization_id, user_id) unique index)
- [x] Re-running the operation does not duplicate effects. (membership-first check; exactly one member row per accept)
- [x] Partial failure cannot silently corrupt state. (failed accept leaves invite pending; recovery update is pending-only; resend never cancels a pre-existing row)
- [x] Public outputs do not expose private or internal data. (signup preview exposes only invited email, org name, status, userExists to the link holder)

## Design

Source of truth stays Postgres via Better Auth; Garden's `acceptInvitationWithSession` wraps `acceptInvitation`, adding a membership short-circuit and mapping APIError codes to product outcomes. Simplest safe approach: use Better Auth's supported `"uuid"` mode rather than fighting the heuristic with a custom callback. Shared invitation vocabulary lives in a client-safe module so server modules export only server functions (a mixed export shipped `pg` to the browser and crashed the app with "Buffer is not defined" — that regression is fixed and covered here).

## Duplicate and idempotency review

- Stable idempotency/dedupe key: (organization_id, user_id) unique index on member.
- Persisted-data duplicate check: membership lookup before accept and in the
  error-recovery path.
- Same-batch duplicate check: n/a — all operations are single-row.
- Retry behavior: repeat clicks hit the membership-first path and reopen the
  workspace; resend refreshes the existing row's expiresAt.
- Conflict behavior: concurrent cancel wins — recovery update carries
  `WHERE status = 'pending'`, so a canceled invite is never resurrected.

## Privacy and security review

- Data classification: recipient email + workspace name, scoped to the link holder.
- Public fields explicitly allowlisted: preview endpoint returns email/orgName/status/userExists only.
- Private links/identifiers suppressed: malformed or non-UUID ids rejected before any DB read.
- Secrets and permissions reviewed: no new secrets; cookies remain HttpOnly + SameSite=Lax; refreshed session cookie is forwarded only onto the same-origin server-fn response.

## Data, migration, and rollback

- Schema/data changes: migration 0045 — `gen_random_uuid()` defaults on `auth_session.id`, `auth_account.id`, auth_verification.id`. Additive, no table rewrite.
- Backup completed or not applicable: not applicable (default-only ALTERs).
- Dry-run/preview result: drizzle-kit generate output reviewed — exactly three `ALTER COLUMN ... SET DEFAULT` statements.
- Expected affected-record count: 0 existing rows touched.
- Rollback procedure: revert `generateId` to the callback and `ALTER COLUMN id DROP DEFAULT` on the three tables. Pending invites survive either direction.

## Verification

- [x] Syntax/build/compile
- [x] Formatting/lint
- [x] Type checks
- [x] Unit tests
- [x] Integration tests
- [x] Repeat-run/idempotency test
- [x] Malformed-input test
- [x] Partial-failure test
- [x] Privacy-output test (unauthenticated preview exposes no extra fields)
- [x] Before/after reconciliation (DB assertions after each browser flow)

Commands and actual results:
pnpm --filter @garden/web exec vitest run     # 50 files, 211 tests passed
pnpm --filter @garden/web typecheck           # clean
pnpm --filter @garden/web lint                # 0 warnings, 0 errors
pnpm --filter @garden/db test                 # 5 tests passed

- integration (real Better Auth + testcontainers Postgres), 15 tests passed: unverified-user accept, idempotent repeat + active org, mismatch, expired, canceled, rejected, used, not_found, membership-limit -> workspace_full, concurrent cancel not resurrected, redirect-id UUID validation.
- browser e2e (Playwright, dev server, real DB), all passed: 
-- invite link -> locked signup -> account -> lands in invited workspace;
-- repeat click reopens workspace; active workspace persists bare navigation;
-- malformed id -> friendly page; exactly one membership; invite accepted;
-- mismatch -> sign-out-and-continue -> locked auth with invite redirect;
-- members tab: expired distinguished, resend refreshes in place, no dupes;
-- forgot-password link + reset redirectTo preserve the invite redirect

- HTTP-level regression check:
-- POST /api/auth/organization/accept-invitation -> 200 for unverified email/password user (previously FORBIDDEN)


## Operations

- Configuration changes: none. Note: long-running dev servers need a restart
  to pick up `RESEND_API_KEY` from .env (invite emails fail loudly otherwise).
- Deployment/restart steps: run migration 0045 against staging with or before
  the web deploy (`pnpm --filter @garden/db db:migrate`) — sign-up inserts
  depend on the new defaults.
- Health checks: send a test invite to a fresh email and complete acceptance.
- Monitoring/alerts: `invitation.accept_failed` and
  `invitation.activate_workspace_failed` logs now carry reason + Better Auth
  error code (previously swallowed).
- Post-deploy verification: pending invites created before the deploy must
  accept successfully (they will — no data change on that table).

## Agent declaration

- [x] I read the applicable `AGENTS.md` instructions.
- [x] I did not perform unapproved destructive production actions.
- [x] I have clearly stated any checks I could not run. (Real Resend delivery of the resend email — the running dev server lacked RESEND_API_KEY in its environment; the send path is identical to normal invite delivery, which was already confirmed working. The failure surfaces as a visible toast.)
- [x] The patch does not include unrelated refactoring.


Closes #104 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Resend pending or expired invitations directly from the members list.
  - Invitation links guide users through sign-in, sign-up, and password recovery while preserving their destination.
  - Users with a different email can sign out and continue with an invitation.

- **Bug Fixes**
  - Improved handling for expired, canceled, used, unavailable, or repeated invitations.
  - Invalid invitation links now show a safe unavailable state.
  - Password resets return users to the intended invitation when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->