### PR TITLE
fix(brain): bind Helix deployment configuration

### DIFF
--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -203,6 +203,8 @@ export const web = await TanStackStart(deployTarget.workerId, {
     BRAIN_FILES: brainFiles,
     FILES: files,
     HYPERDRIVE: database,
+    HELIX_URL: plainEnv('HELIX_URL'),
+    HELIX_API_KEY: alchemy.secret.env.HELIX_API_KEY,
     DATABASE_URL: alchemy.secret.env.DATABASE_URL,
     BETTER_AUTH_SECRET: alchemy.secret.env.BETTER_AUTH_SECRET,
     RESEND_API_KEY: alchemy.secret.env.RESEND_API_KEY,

--- a/scripts/verify-deploy-config.mjs
+++ b/scripts/verify-deploy-config.mjs
@@ -109,7 +109,10 @@ assert.match(
   modelSource,
   /DEFAULT_AGENT_MODEL_PROFILE =\s*\n?\s*agentModelProfiles\.kimiK27CodeWorkersAi/,
 )
-assert.match(modelSource, /:\s*'workers-ai'\s*\n\s*if \(provider === 'workers-ai'\) return DEFAULT_AGENT_MODEL_PROFILE/)
+assert.match(
+  modelSource,
+  /:\s*'workers-ai'\s*\n\s*if \(provider === 'workers-ai'\) return DEFAULT_AGENT_MODEL_PROFILE/,
+)
 
 const uniqueFields = [
   'appName',
@@ -156,8 +159,11 @@ for (const binding of [
   'EXECUTOR_MCP_SESSION',
   'EXECUTOR_MCP_EXECUTION_OWNER',
   'RUN_WORKFLOW',
+  'BRAIN_FILES',
   'FILES',
   'HYPERDRIVE',
+  'HELIX_URL',
+  'HELIX_API_KEY',
   'LOADER',
   'BROWSER',
   'AI',
@@ -168,6 +174,12 @@ for (const binding of [
     `Alchemy must declare ${binding}`,
   )
 }
+
+assert.match(alchemySource, /HELIX_URL:\s*plainEnv\('HELIX_URL'\)/)
+assert.match(
+  alchemySource,
+  /HELIX_API_KEY:\s*alchemy\.secret\.env\.HELIX_API_KEY/,
+)
 
 for (const field of [
   'workerName',


### PR DESCRIPTION
## Summary

The deployed Files page currently fails with `Brain is not configured (missing HELIX_URL)` because Alchemy does not pass the Helix configuration to the Worker.

This PR:

- binds `HELIX_URL` as plain runtime configuration;
- binds `HELIX_API_KEY` as a Worker secret;
- extends the deployment check to cover the Helix and `BRAIN_FILES` bindings.

## Verification

- `pnpm run verify:deploy-config`
- focused `oxfmt` check
- focused `oxlint` check: 0 warnings and 0 errors

## Deployment note

The Cloudflare build environment must provide `HELIX_URL` and `HELIX_API_KEY` before this change deploys.