### PR TITLE
fix(infra): preserve production automation trigger identity

### DIFF
--- a/deploy-targets.mjs
+++ b/deploy-targets.mjs
@@ -25,7 +25,11 @@ export const deploymentTargets = {
     executorBlobsId: 'executor-blobs',
     executorBlobsBucket: 'harnessy-connectors-blobs',
     agentDoId: 'agent-do',
-    automationTriggerId: 'automation-trigger',
+    // The v1 Worker tag stored the runtime binding name `AUTOMATION_TRIGGER`
+    // as the class for logical ID `automation-trigger`. Use the binding name as
+    // the v2 logical ID so adoption matches the observed `AutomationTriggerDO`
+    // class instead of asking Cloudflare to rename a non-existent class.
+    automationTriggerId: 'AUTOMATION_TRIGGER',
     workflowId: 'run-workflow',
     workflowName: 'garden-run-workflow-staging',
     sandboxId: 'sandbox',

--- a/scripts/verify-deploy-config.mjs
+++ b/scripts/verify-deploy-config.mjs
@@ -129,7 +129,6 @@ const uniqueFields = [
   'executorBlobsId',
   'executorBlobsBucket',
   'agentDoId',
-  'automationTriggerId',
   'workflowId',
   'workflowName',
   'sandboxId',
@@ -147,6 +146,14 @@ for (const field of uniqueFields) {
     assert.equal(typeof value, 'string', `${field} must be a string`)
     assert.notEqual(value.length, 0, `${field} must not be empty`)
   }
+}
+
+for (const target of Object.values(deploymentTargets)) {
+  assert.equal(
+    target.automationTriggerId,
+    'AUTOMATION_TRIGGER',
+    `${target.key} must preserve the adopted automation trigger identity`,
+  )
 }
 
 for (const binding of [


### PR DESCRIPTION
## what changed

- preserves the existing production automation trigger identity during Alchemy v2 adoption
- adds a deployment config check for both targets

## why

The first production deployment exposed a stale v1 tag. It identified `AUTOMATION_TRIGGER` as a class name, so Alchemy tried an invalid class rename.

This change keeps the existing Worker binding and `AutomationTriggerDO` class unchanged. It only corrects Alchemy's internal identity mapping.

## verified

- deployment config check passed
- workspace typecheck passed: 12/12
- production dry run showed no resource deletion or replacement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated production deployment configuration to use the correct automation trigger identity.
  - Deployment configuration verification now confirms that all targets use the shared automation trigger identity.
  - Preview deployment settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->